### PR TITLE
Make operator less verbose

### DIFF
--- a/pkg/controller/cassandracluster/reconcile.go
+++ b/pkg/controller/cassandracluster/reconcile.go
@@ -161,7 +161,6 @@ func (rcc *ReconcileCassandraCluster) CheckNonAllowedChanges(cc *api.CassandraCl
 		}
 	}
 
-
 	if needUpdate {
 		status.LastClusterAction = api.ActionCorrectCRDConfig.Name
 		ClusterActionMetric.set(api.ActionCorrectCRDConfig, cc.Name)
@@ -715,7 +714,7 @@ func (rcc *ReconcileCassandraCluster) CheckPodsState(cc *api.CassandraCluster,
 		return err
 	}
 
-	podToDelete, err := processingPods(hostIDMap, cc.Spec.RestartCountBeforePodDeletion , podsList, status)
+	podToDelete, err := processingPods(hostIDMap, cc.Spec.RestartCountBeforePodDeletion, podsList, status)
 	if err != nil {
 		return err
 	}
@@ -739,7 +738,6 @@ func (rcc *ReconcileCassandraCluster) ListCassandraClusterPods(cc *api.Cassandra
 				return nil, fmt.Errorf("Name uses for DC and/or Rack are not good")
 			}
 
-			logrus.WithFields(logrus.Fields{"cluster": cc.Name, "dc-rack": dcRackName}).Info("We will list available pods")
 			pods, err := rcc.ListPods(cc.Namespace, k8s.LabelsForCassandraDCRack(cc, dcName, rackName))
 			if err != nil {
 				return nil, err
@@ -772,12 +770,12 @@ func updateCassandraNodesStatusForPod(hostIDMap map[string]string, pod *v1.Pod, 
 
 	// Update Pod, HostId, Ip couple cached into status
 	hostId, keyFound := hostIDMap[pod.Status.PodIP]
-	if keyFound == true && cassandraPodIsReady(pod){
+	if keyFound == true && cassandraPodIsReady(pod) {
 		status.CassandraNodesStatus[pod.Name] = api.CassandraNodeStatus{HostId: hostId, NodeIp: pod.Status.PodIP}
 	}
 }
 
-func checkPodCrossIpUseCaseForPod(hostIDMap map[string]string, pod *v1.Pod, status *api.CassandraClusterStatus) (*v1.Pod, error){
+func checkPodCrossIpUseCaseForPod(hostIDMap map[string]string, pod *v1.Pod, status *api.CassandraClusterStatus) (*v1.Pod, error) {
 
 	// We compare the hostId associated to the pod (cached into the resource status) and the one associated
 	// to the podIp into the cassandra cluster.
@@ -789,7 +787,7 @@ func checkPodCrossIpUseCaseForPod(hostIDMap map[string]string, pod *v1.Pod, stat
 	// that the one associated into cassandra for the same IP, so we are in IP cross cases.
 	if keyFound == true && statusHostId != hostId {
 		logrus.WithFields(logrus.Fields{"pod": pod.Name}).
-			Info(fmt.Sprintf("Pod %s, have a cross Ip situation. The pod have ip : %s, with hostId : %s, " +
+			Info(fmt.Sprintf("Pod %s, have a cross Ip situation. The pod have ip : %s, with hostId : %s, "+
 				"but this ip is already associated to the hostId : %s. We force delete of the pod", pod.Name, pod.Status.PodIP, statusHostId, hostId))
 		return pod, nil
 	}


### PR DESCRIPTION
This PR removes info log that constitutes half of my logs and doesn't tell much (`We will list available pod`). I don't think logging get requests is necessary, only errors or commands.

What do you think?