### PR TITLE
Fixed helm name to cassandra-operator in documentation

### DIFF
--- a/website/docs/2_setup/1_getting_started.md
+++ b/website/docs/2_setup/1_getting_started.md
@@ -50,7 +50,7 @@ Then the chart itself depending on your installed version of Helm:
 ```bash
 # You have to create the namespace before executing following command
 kubectl apply -f https://raw.githubusercontent.com/Orange-OpenSource/casskop/master/deploy/crds/db.orange.com_cassandraclusters_crd.yaml
-helm install casskop --namespace=cassandra orange-incubator/casskop
+helm install casskop --namespace=cassandra orange-incubator/cassandra-operator
 ```
 
 </TabItem>
@@ -64,7 +64,7 @@ kubectl create -f tiller-clusterrolebinding.yaml
 helm init --service-account tiller --upgrade
 
 # Deploy operator
-helm install --name=casskop --namespace=cassandra orange-incubator/casskop
+helm install --name=casskop --namespace=cassandra orange-incubator/cassandra-operator
 ```
 
 </TabItem>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes (Doc Fix)
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no


### What's in this PR?
Quick fix of the documentation

### Why?
The new documentation use casskop as helm name instead of cassandra-operator.
Bigger fix to come next week

### Checklist
- [X ] User guide and development docs updated (if needed)

