### PR TITLE
Set bootstrap env vars based on Cassandra resources

### DIFF
--- a/pkg/apis/db/v1alpha1/cassandracluster_types.go
+++ b/pkg/apis/db/v1alpha1/cassandracluster_types.go
@@ -26,10 +26,9 @@ import (
 )
 
 const (
-
-	DefaultLivenessInitialDelaySeconds 	int32 = 120
-	DefaultLivenessHealthCheckTimeout  	int32 = 20
-	DefaultLivenessHealthCheckPeriod   	int32 = 10
+	DefaultLivenessInitialDelaySeconds int32 = 120
+	DefaultLivenessHealthCheckTimeout  int32 = 20
+	DefaultLivenessHealthCheckPeriod   int32 = 10
 
 	DefaultReadinessInitialDelaySeconds int32 = 60
 	DefaultReadinessHealthCheckTimeout  int32 = 10
@@ -413,7 +412,7 @@ func (cc *CassandraCluster) InitSeedList() []string {
 	return seedList
 }
 
-func (cc *CassandraCluster) GetSeedList(seedListTab *[]string) string {
+func (cc *CassandraCluster) SeedList(seedListTab *[]string) string {
 	seedList := strings.Join(*seedListTab, ",")
 	return seedList
 }
@@ -544,7 +543,7 @@ func (cc *CassandraCluster) GetDCIndexFromDCName(dcName string) int {
 		return -1
 	}
 
-	for dc := 0; dc < dcSize; dc ++ {
+	for dc := 0; dc < dcSize; dc++ {
 		if dcName == cc.GetDCName(dc) {
 			return dc
 		}
@@ -557,7 +556,7 @@ func (cc *CassandraCluster) getDCFromIndex(dc int) *DC {
 	if dc >= cc.GetDCSize() {
 		return nil
 	}
-	return  &cc.Spec.Topology.DC[dc]
+	return &cc.Spec.Topology.DC[dc]
 }
 
 // GetNodesPerRacks sends back the number of cassandra nodes to uses for this dc-rack
@@ -612,7 +611,7 @@ func (cc *CassandraCluster) GetDCNodesPerRacksFromDCRackName(dcRackName string) 
 }
 
 // GetNodesPerRacks sends back the number of cassandra nodes to uses for this dc-rack
-func (cc *CassandraCluster) GetNumTokensPerRacks(dcRackName string) int32 {
+func (cc *CassandraCluster) NumTokensPerRacks(dcRackName string) int32 {
 	dcsize := cc.GetDCSize()
 
 	if dcsize < 1 {
@@ -785,7 +784,7 @@ type CassandraClusterSpec struct {
 	// RestartCountBeforePodDeletion defines the number of restart allowed for a cassandra container allowed before
 	// deleting the pod  to force its restart from scratch. if set to 0 or omit,
 	// no action will be performed based on restart count.
-	RestartCountBeforePodDeletion	int32	`json:"restartCountBeforePodDeletion,omitempty"`
+	RestartCountBeforePodDeletion int32 `json:"restartCountBeforePodDeletion,omitempty"`
 
 	// Very special Flag to hack CassKop reconcile loop - use with really good Care
 	UnlockNextOperation bool `json:"unlockNextOperation,omitempty"`
@@ -824,7 +823,7 @@ type CassandraClusterSpec struct {
 
 	// LivenessInitialDelaySeconds defines initial delay for the liveness probe of the main
 	// cassandra container : https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
-	LivenessInitialDelaySeconds	*int32 `json:"livenessInitialDelaySeconds,omitempty"`
+	LivenessInitialDelaySeconds *int32 `json:"livenessInitialDelaySeconds,omitempty"`
 	// LivenessHealthCheckTimeout defines health check timeout for the liveness probe of the main
 	// cassandra container : https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
 	LivenessHealthCheckTimeout *int32 `json:"livenessHealthCheckTimeout,omitempty"`
@@ -977,7 +976,7 @@ type CassandraClusterStatus struct {
 
 	//
 	CassandraNodesStatus map[string]CassandraNodeStatus `json:"cassandraNodeStatus,omitempty"`
-	
+
 	//CassandraRackStatusList list status for each Rack
 	CassandraRackStatus map[string]*CassandraRackStatus `json:"cassandraRackStatus,omitempty"`
 }

--- a/pkg/apis/db/v1alpha1/cassandracluster_types_test.go
+++ b/pkg/apis/db/v1alpha1/cassandracluster_types_test.go
@@ -19,6 +19,7 @@ import (
 	"log"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/ghodss/yaml"
@@ -92,7 +93,7 @@ func TestGetNumTokensPerRacks_NoTopo(t *testing.T) {
 
 	cc := helperInitCluster(t, "cassandracluster-NoTopo.yaml")
 
-	nodesPerRack := cc.GetNumTokensPerRacks("dc-rack1")
+	nodesPerRack := cc.NumTokensPerRacks("dc-rack1")
 
 	assert.Equal(int32(256), nodesPerRack)
 
@@ -102,16 +103,16 @@ func TestGetNumTokensPerRacks_2DC(t *testing.T) {
 
 	cc := helperInitCluster(t, "cassandracluster-2DC.yaml")
 
-	numTokens := cc.GetNumTokensPerRacks("online-rack1")
+	numTokens := cc.NumTokensPerRacks("online-rack1")
 	assert.Equal(int32(200), numTokens)
 
-	numTokens = cc.GetNumTokensPerRacks("online-rack2")
+	numTokens = cc.NumTokensPerRacks("online-rack2")
 	assert.Equal(int32(200), numTokens)
 
-	numTokens = cc.GetNumTokensPerRacks("stats-rack1")
+	numTokens = cc.NumTokensPerRacks("stats-rack1")
 	assert.Equal(int32(32), numTokens)
 
-	numTokens = cc.GetNumTokensPerRacks("toto-toto")
+	numTokens = cc.NumTokensPerRacks("toto-toto")
 	assert.Equal(int32(256), numTokens)
 
 }
@@ -320,13 +321,14 @@ func TestInitSeedList_2DC(t *testing.T) {
 
 	cc.Status.SeedList = cc.InitSeedList()
 
-	assert.Equal("cassandra-demo-online-rack1-0.cassandra-demo.ns", cc.Status.SeedList[0])
-	assert.Equal("cassandra-demo-online-rack1-1.cassandra-demo.ns", cc.Status.SeedList[1])
-	assert.Equal("cassandra-demo-online-rack2-0.cassandra-demo.ns", cc.Status.SeedList[2])
-	assert.Equal("cassandra-demo-stats-rack1-0.cassandra-demo.ns", cc.Status.SeedList[3])
-	assert.Equal("cassandra-demo-stats-rack1-1.cassandra-demo.ns", cc.Status.SeedList[4])
-	assert.Equal("cassandra-demo-stats-rack2-0.cassandra-demo.ns", cc.Status.SeedList[5])
-	assert.Equal(6, len(cc.Status.SeedList))
+	assert.Equal([]string{
+		"cassandra-demo-online-rack1-0.cassandra-demo.ns",
+		"cassandra-demo-online-rack1-1.cassandra-demo.ns",
+		"cassandra-demo-online-rack2-0.cassandra-demo.ns",
+		"cassandra-demo-stats-rack1-0.cassandra-demo.ns",
+		"cassandra-demo-stats-rack1-1.cassandra-demo.ns",
+		"cassandra-demo-stats-rack2-0.cassandra-demo.ns",
+	}, cc.Status.SeedList)
 }
 
 func TestInitSeedList_NoTopo(t *testing.T) {
@@ -334,17 +336,16 @@ func TestInitSeedList_NoTopo(t *testing.T) {
 
 	cc := helperInitCluster(t, "cassandracluster-NoTopo.yaml")
 
-	//cc.InitCassandraRackList()
-
 	assert.Equal(ClusterPhaseInitial.Name, cc.Status.CassandraRackStatus["dc1-rack1"].CassandraLastAction.Name)
 	assert.Equal(1, len(cc.Status.CassandraRackStatus))
 
 	cc.Status.SeedList = cc.InitSeedList()
 
-	assert.Equal("cassandra-demo-dc1-rack1-0.cassandra-demo.ns", cc.Status.SeedList[0])
-	assert.Equal("cassandra-demo-dc1-rack1-1.cassandra-demo.ns", cc.Status.SeedList[1])
-	assert.Equal("cassandra-demo-dc1-rack1-2.cassandra-demo.ns", cc.Status.SeedList[2])
-	assert.Equal(3, len(cc.Status.SeedList))
+	assert.Equal([]string{
+		"cassandra-demo-dc1-rack1-0.cassandra-demo.ns",
+		"cassandra-demo-dc1-rack1-1.cassandra-demo.ns",
+		"cassandra-demo-dc1-rack1-2.cassandra-demo.ns",
+	}, cc.Status.SeedList)
 
 }
 
@@ -361,12 +362,11 @@ func TestInitSeedList_1DC(t *testing.T) {
 
 	cc.Status.SeedList = cc.InitSeedList()
 
-	assert.Equal("cassandra-demo-online-rack1-0.cassandra-demo.ns", cc.Status.SeedList[0])
-	assert.Equal("cassandra-demo-online-rack1-1.cassandra-demo.ns", cc.Status.SeedList[1])
-	assert.Equal("cassandra-demo-online-rack2-0.cassandra-demo.ns", cc.Status.SeedList[2])
-	assert.Equal(3, len(cc.Status.SeedList))
-
-	assert.Equal("cassandra-demo-online-rack1-0.cassandra-demo.ns,cassandra-demo-online-rack1-1.cassandra-demo.ns,cassandra-demo-online-rack2-0.cassandra-demo.ns", cc.GetSeedList(&cc.Status.SeedList))
+	assert.Equal(strings.Join([]string{
+		"cassandra-demo-online-rack1-0.cassandra-demo.ns",
+		"cassandra-demo-online-rack1-1.cassandra-demo.ns",
+		"cassandra-demo-online-rack2-0.cassandra-demo.ns",
+	}, ","), cc.SeedList(&cc.Status.SeedList))
 
 }
 
@@ -390,15 +390,18 @@ func TestInitSeedList_2DC5R(t *testing.T) {
 
 	cc.Status.SeedList = cc.InitSeedList()
 
-	assert.Equal("cassandra-demo-online-rack1-0.cassandra-demo.ns", cc.Status.SeedList[0])
-	assert.Equal("cassandra-demo-online-rack2-0.cassandra-demo.ns", cc.Status.SeedList[1])
-	assert.Equal("cassandra-demo-online-rack3-0.cassandra-demo.ns", cc.Status.SeedList[2])
-	assert.Equal("cassandra-demo-stats-rack1-0.cassandra-demo.ns", cc.Status.SeedList[3])
-	assert.Equal("cassandra-demo-stats-rack2-0.cassandra-demo.ns", cc.Status.SeedList[4])
-	assert.Equal("cassandra-demo-stats-rack3-0.cassandra-demo.ns", cc.Status.SeedList[5])
-	assert.Equal(6, len(cc.Status.SeedList))
+	seeds := []string{
+		"cassandra-demo-online-rack1-0.cassandra-demo.ns",
+		"cassandra-demo-online-rack2-0.cassandra-demo.ns",
+		"cassandra-demo-online-rack3-0.cassandra-demo.ns",
+		"cassandra-demo-stats-rack1-0.cassandra-demo.ns",
+		"cassandra-demo-stats-rack2-0.cassandra-demo.ns",
+		"cassandra-demo-stats-rack3-0.cassandra-demo.ns",
+	}
 
-	assert.Equal("cassandra-demo-online-rack1-0.cassandra-demo.ns,cassandra-demo-online-rack2-0.cassandra-demo.ns,cassandra-demo-online-rack3-0.cassandra-demo.ns,cassandra-demo-stats-rack1-0.cassandra-demo.ns,cassandra-demo-stats-rack2-0.cassandra-demo.ns,cassandra-demo-stats-rack3-0.cassandra-demo.ns", cc.GetSeedList(&cc.Status.SeedList))
+	assert.Equal(seeds, cc.Status.SeedList)
+
+	assert.Equal(strings.Join(seeds, ","), cc.SeedList(&cc.Status.SeedList))
 }
 
 func TestInitSeedList_1DC1R1P(t *testing.T) {
@@ -414,11 +417,12 @@ func TestInitSeedList_1DC1R1P(t *testing.T) {
 
 	cc.Status.SeedList = cc.InitSeedList()
 
-	assert.Equal("cassandra-demo-online-rack1-0.cassandra-demo.ns", cc.Status.SeedList[0])
-	assert.Equal("cassandra-demo-online-rack2-0.cassandra-demo.ns", cc.Status.SeedList[1])
-	assert.Equal(2, len(cc.Status.SeedList))
-
-	assert.Equal("cassandra-demo-online-rack1-0.cassandra-demo.ns,cassandra-demo-online-rack2-0.cassandra-demo.ns", cc.GetSeedList(&cc.Status.SeedList))
+	assert.Equal(
+		strings.Join([]string{
+			"cassandra-demo-online-rack1-0.cassandra-demo.ns",
+			"cassandra-demo-online-rack2-0.cassandra-demo.ns",
+		}, ","),
+		cc.SeedList(&cc.Status.SeedList))
 }
 
 func TestIsPodInSeedList(t *testing.T) {
@@ -432,11 +436,12 @@ func TestIsPodInSeedList(t *testing.T) {
 
 	cc.Status.SeedList = cc.InitSeedList()
 
-	assert.Equal("cassandra-demo-online-rack1-0.cassandra-demo.ns", cc.Status.SeedList[0])
-	assert.Equal("cassandra-demo-online-rack2-0.cassandra-demo.ns", cc.Status.SeedList[1])
-	assert.Equal(2, len(cc.Status.SeedList))
-
-	assert.Equal("cassandra-demo-online-rack1-0.cassandra-demo.ns,cassandra-demo-online-rack2-0.cassandra-demo.ns", cc.GetSeedList(&cc.Status.SeedList))
+	assert.Equal(
+		strings.Join([]string{
+			"cassandra-demo-online-rack1-0.cassandra-demo.ns",
+			"cassandra-demo-online-rack2-0.cassandra-demo.ns",
+		}, ","),
+		cc.SeedList(&cc.Status.SeedList))
 
 	assert.Equal(true, cc.IsPodInSeedList("cassandra-demo-online-rack1-0.cassandra-demo.ns"))
 	assert.Equal(true, cc.IsPodInSeedList("cassandra-demo-online-rack2-0.cassandra-demo.ns"))

--- a/pkg/controller/cassandracluster/cassandra_status_test.go
+++ b/pkg/controller/cassandracluster/cassandra_status_test.go
@@ -36,7 +36,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var name string = "cassandra-demo"
+var clusterName string = "cassandra-demo"
 var namespace string = "ns"
 
 var cc2Dcs = `

--- a/pkg/controller/cassandracluster/cassandra_status_test.go
+++ b/pkg/controller/cassandracluster/cassandra_status_test.go
@@ -195,7 +195,7 @@ func helperCreateCassandraCluster(t *testing.T, cassandraClusterFileName string)
 				Status: v1.PodStatus{
 					Phase: v1.PodRunning,
 					ContainerStatuses: []v1.ContainerStatus{
-						v1.ContainerStatus{
+						{
 							Name: "cassandra",
 							//Image: cc.Spec.BaseImage + ":" + cc.Spec.Version
 							Ready: true,

--- a/pkg/controller/cassandracluster/generator.go
+++ b/pkg/controller/cassandracluster/generator.go
@@ -401,9 +401,20 @@ func generateCassandraStatefulSet(cc *api.CassandraCluster, status *api.Cassandr
 	}
 
 	// Merge cassandra main container environment variables into sidecars.
+
+	var sidecarEnv []v1.EnvVar
+
+	// Collect all env vars from bootstrap container except the heap size
+	for _, env := range bootstrapContainer.Env {
+		if env.Name != cassandraMaxHeap {
+			sidecarEnv = append(sidecarEnv, env)
+		}
+	}
+
+	// Add all those env vars to each sidecar
 	for idx, container := range ss.Spec.Template.Spec.Containers {
 		if container.Name != cassandraContainerName {
-			ss.Spec.Template.Spec.Containers[idx].Env = append(container.Env, bootstrapContainer.Env...)
+			ss.Spec.Template.Spec.Containers[idx].Env = append(container.Env, sidecarEnv...)
 		}
 	}
 

--- a/pkg/controller/cassandracluster/generator.go
+++ b/pkg/controller/cassandracluster/generator.go
@@ -45,6 +45,7 @@ type JvmMemory struct {
 const (
 	cassandraContainerName = "cassandra"
 	bootstrapContainerName = "bootstrap"
+	cassandraMaxHeap       = "CASSANDRA_MAX_HEAP"
 	defaultJvmMaxHeap      = "2048M"
 	hostnameTopologyKey    = "kubernetes.io/hostname"
 
@@ -456,29 +457,29 @@ func generatePodDisruptionBudget(name string, namespace string, labels map[strin
 	}
 }
 
-func getCassandraResources(spec api.CassandraClusterSpec) v1.ResourceRequirements {
+func cassandraResources(spec api.CassandraClusterSpec) v1.ResourceRequirements {
 	return v1.ResourceRequirements{
-		Requests: getRequests(spec.Resources),
-		Limits:   getLimits(spec.Resources),
+		Requests: requests(spec.Resources),
+		Limits:   limits(spec.Resources),
 	}
 }
 
-func getInitContainerResources() v1.ResourceRequirements {
+func initContainerResources() v1.ResourceRequirements {
 	resources := api.CassandraResources{
 		Limits:   api.CPUAndMem{Memory: defaultInitContainerLimitsMemory, CPU: defaultInitContainerLimitsCPU},
 		Requests: api.CPUAndMem{Memory: defaultInitContainerRequestsMemory, CPU: defaultInitContainerRequestsCPU},
 	}
 	return v1.ResourceRequirements{
-		Limits:   getRequests(resources),
-		Requests: getLimits(resources),
+		Limits:   requests(resources),
+		Requests: limits(resources),
 	}
 }
 
-func getLimits(resources api.CassandraResources) v1.ResourceList {
+func limits(resources api.CassandraResources) v1.ResourceList {
 	return generateResourceList(resources.Limits.CPU, resources.Limits.Memory)
 }
 
-func getRequests(resources api.CassandraResources) v1.ResourceList {
+func requests(resources api.CassandraResources) v1.ResourceList {
 	return generateResourceList(resources.Requests.CPU, resources.Requests.Memory)
 }
 
@@ -555,12 +556,12 @@ func createPodAntiAffinity(hard bool, labels map[string]string) *v1.PodAntiAffin
 	}
 }
 
-func createEnvVarForBootstrapContainer(cc *api.CassandraCluster, status *api.CassandraClusterStatus,
+func bootstrapContainerEnvVar(cc *api.CassandraCluster, status *api.CassandraClusterStatus,
 	resources v1.ResourceRequirements, dcRackName string) []v1.EnvVar {
 	name := cc.GetName()
 	//in statefulset.go we surcharge this value with conditions
-	seedList := cc.GetSeedList(&status.SeedList)
-	numTokensPerRacks := cc.GetNumTokensPerRacks(dcRackName)
+	seedList := cc.SeedList(&status.SeedList)
+	numTokensPerRacks := cc.NumTokensPerRacks(dcRackName)
 
 	return []v1.EnvVar{
 		{
@@ -616,7 +617,7 @@ func createEnvVarForBootstrapContainer(cc *api.CassandraCluster, status *api.Cas
 // createInitConfigContainer allows to copy origin config files from init-config container to /bootstrap directory
 // where it will be surcharged by casskop needs, and by user's configmap changes
 func createInitConfigContainer(cc *api.CassandraCluster) v1.Container {
-	resources := getInitContainerResources()
+	resources := initContainerResources()
 	volumeMounts := generateContainerVolumeMount(cc, initContainer)
 
 	return v1.Container{
@@ -639,9 +640,9 @@ func createCassandraBootstrapContainer(cc *api.CassandraCluster, status *api.Cas
 		Name:            bootstrapContainerName,
 		Image:           cc.Spec.BootstrapImage,
 		ImagePullPolicy: cc.Spec.ImagePullPolicy,
-		Env:             createEnvVarForBootstrapContainer(cc, status, getCassandraResources(cc.Spec), dcRackName),
+		Env:             bootstrapContainerEnvVar(cc, status, cassandraResources(cc.Spec), dcRackName),
 		VolumeMounts:    volumeMounts,
-		Resources:       getInitContainerResources(),
+		Resources:       initContainerResources(),
 	}
 }
 
@@ -668,7 +669,7 @@ func generateContainers(cc *api.CassandraCluster, status *api.CassandraClusterSt
 func createCassandraContainer(cc *api.CassandraCluster, status *api.CassandraClusterStatus,
 	dcRackName string) v1.Container {
 
-	resources := getCassandraResources(cc.Spec)
+	resources := cassandraResources(cc.Spec)
 	volumeMounts := append(generateContainerVolumeMount(cc, cassandraContainer), generateStorageConfigVolumesMount(cc)...)
 
 	var command = []string{}

--- a/pkg/controller/cassandracluster/generator.go
+++ b/pkg/controller/cassandracluster/generator.go
@@ -49,10 +49,10 @@ const (
 	hostnameTopologyKey    = "kubernetes.io/hostname"
 
 	// InitContainer resources
-	defaultInitContainerLimitsCPU       = "0.5"
-	defaultInitContainerLimitsMemory    = "0.5Gi"
-	defaultInitContainerRequestsCPU     = "0.5"
-	defaultInitContainerRequestsMemory  = "0.5Gi"
+	defaultInitContainerLimitsCPU      = "0.5"
+	defaultInitContainerLimitsMemory   = "0.5Gi"
+	defaultInitContainerRequestsCPU    = "0.5"
+	defaultInitContainerRequestsMemory = "0.5Gi"
 
 	cassandraConfigMapName = "cassandra-config"
 )
@@ -88,7 +88,7 @@ func generateCassandraService(cc *api.CassandraCluster, labels map[string]string
 			Type:      v1.ServiceTypeClusterIP,
 			ClusterIP: v1.ClusterIPNone,
 			Ports: []v1.ServicePort{
-				v1.ServicePort{
+				{
 					Port:     cassandraPort,
 					Protocol: v1.ProtocolTCP,
 					Name:     cassandraPortName,
@@ -121,7 +121,7 @@ func generateCassandraExporterService(cc *api.CassandraCluster, labels map[strin
 			Type:      v1.ServiceTypeClusterIP,
 			ClusterIP: v1.ClusterIPNone,
 			Ports: []v1.ServicePort{
-				v1.ServicePort{
+				{
 					Port:     exporterCassandraJmxPort,
 					Protocol: v1.ProtocolTCP,
 					Name:     exporterCassandraJmxPortName,
@@ -213,7 +213,7 @@ func generateStorageConfigVolumeClaimTemplates(cc *api.CassandraCluster, labels 
 
 	for _, storage := range cc.Spec.StorageConfigs {
 		if storage.PVCSpec == nil {
-			return nil, fmt.Errorf("Can't create PVC from storageConfig named %s, with mountPath %s, because the PvcSpec is not specified.", storage.Name, storage.MountPath)
+			return nil, fmt.Errorf("Can't create PVC from storageConfig named %s, with mountPath %s, because the PvcSpec is not specified", storage.Name, storage.MountPath)
 		}
 		pvc := v1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{
@@ -240,7 +240,7 @@ func generateVolumeClaimTemplate(cc *api.CassandraCluster, labels map[string]str
 	}
 
 	pvc = []v1.PersistentVolumeClaim{
-		v1.PersistentVolumeClaim{
+		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:   "data",
 				Labels: labels,
@@ -546,7 +546,7 @@ func createPodAntiAffinity(hard bool, labels map[string]string) *v1.PodAntiAffin
 	// Return a SOFT anti-affinity
 	return &v1.PodAntiAffinity{
 		PreferredDuringSchedulingIgnoredDuringExecution: []v1.WeightedPodAffinityTerm{
-			v1.WeightedPodAffinityTerm{
+			{
 				Weight:          100,
 				PodAffinityTerm: podAffinityTerm,
 			},

--- a/pkg/controller/cassandracluster/generator.go
+++ b/pkg/controller/cassandracluster/generator.go
@@ -366,6 +366,7 @@ func generateCassandraStatefulSet(cc *api.CassandraCluster, status *api.Cassandr
 	for _, container := range ss.Spec.Template.Spec.InitContainers {
 		if container.Name == bootstrapContainerName {
 			bootstrapContainer = container
+			break
 		}
 	}
 

--- a/pkg/controller/cassandracluster/generator_test.go
+++ b/pkg/controller/cassandracluster/generator_test.go
@@ -147,7 +147,6 @@ func TestGenerateCassandraStatefulSet(t *testing.T) {
 	labels, nodeSelector := k8s.GetDCRackLabelsAndNodeSelectorForStatefulSet(cc, 0, 0)
 	sts, _ := generateCassandraStatefulSet(cc, &cc.Status, dcName, dcRackName, labels, nodeSelector, nil)
 
-
 	assert.Equal(map[string]string{
 		"app":                                  "cassandracluster",
 		"cassandracluster":                     "cassandra-demo",
@@ -166,7 +165,7 @@ func TestGenerateCassandraStatefulSet(t *testing.T) {
 
 	checkVolumeClaimTemplates(t, labels, sts.Spec.VolumeClaimTemplates, "10Gi", "test-storage")
 	checkLiveAndReadiNessProbe(t, sts.Spec.Template.Spec.Containers,
-		1010, 201, 32, 7, 9,1205, 151, 17, 50, 30)
+		1010, 201, 32, 7, 9, 1205, 151, 17, 50, 30)
 	checkVolumeMount(t, sts.Spec.Template.Spec.Containers)
 	checkVarEnv(t, sts.Spec.Template.Spec.Containers, cc, dcRackName)
 	checkDefaultInitContainerResources(t, sts.Spec.Template.Spec.InitContainers)
@@ -187,7 +186,7 @@ func TestGenerateCassandraStatefulSet(t *testing.T) {
 
 	checkVolumeClaimTemplates(t, labels, stsDefault.Spec.VolumeClaimTemplates, "3Gi", "local-storage")
 	checkLiveAndReadiNessProbe(t, stsDefault.Spec.Template.Spec.Containers,
-		60, 10, 10, 0,0, 120, 20, 10, 0, 0)
+		60, 10, 10, 0, 0, 120, 20, 10, 0, 0)
 	checkDefaultInitContainerResources(t, stsDefault.Spec.Template.Spec.InitContainers)
 
 }
@@ -234,8 +233,6 @@ func checkLiveAndReadiNessProbe(t *testing.T, containers []v1.Container,
 		}
 	}
 }
-
-
 
 func checkVolumeClaimTemplates(t *testing.T, expectedlabels map[string]string, pvcs []v1.PersistentVolumeClaim,
 	dataCapacity, dataClassStorage string) {
@@ -362,7 +359,7 @@ func checkVolumeMount(t *testing.T, containers []v1.Container) {
 
 func checkDefaultInitContainerResources(t *testing.T, containers []v1.Container) {
 	resources := api.CassandraResources{
-		Limits: api.CPUAndMem{Memory: defaultInitContainerLimitsMemory, CPU: defaultInitContainerLimitsCPU},
+		Limits:   api.CPUAndMem{Memory: defaultInitContainerLimitsMemory, CPU: defaultInitContainerLimitsCPU},
 		Requests: api.CPUAndMem{Memory: defaultInitContainerRequestsMemory, CPU: defaultInitContainerRequestsCPU},
 	}
 	resourcesRequirements := v1.ResourceRequirements{
@@ -400,7 +397,7 @@ func generateCassandraStorageConfigVolumeMounts() []v1.VolumeMount {
 
 func checkVarEnv(t *testing.T, containers []v1.Container, cc *api.CassandraCluster, dcRackName string) {
 	resources := getCassandraResources(cc.Spec)
-	envs := createEnvVarForCassandraContainer(cc, &cc.Status, resources, dcRackName)
+	envs := createEnvVarForBootstrapContainer(cc, &cc.Status, resources, dcRackName)
 
 	for _, container := range containers {
 		for _, env := range envs {

--- a/pkg/controller/cassandracluster/generator_test.go
+++ b/pkg/controller/cassandracluster/generator_test.go
@@ -414,7 +414,9 @@ func checkVarEnv(t *testing.T, containers []v1.Container, cc *api.CassandraClust
 	}
 
 	assert.True(cassandraMaxHeapSet)
+	assert.Equal(envVar[cassandraMaxHeap], "512M")
 
+	// The cassandra heap should not be set on other containers
 	delete(envVar, cassandraMaxHeap)
 
 	for name, value := range envVar {

--- a/test/e2e/cassandracluster_test.go
+++ b/test/e2e/cassandracluster_test.go
@@ -405,8 +405,8 @@ func cassandraClusterCleanupTest(t *testing.T, f *framework.Framework, ctx *fram
 			return false, nil
 		}
 
-		if !endTime.After(startTime) {
-			t.Logf("Expected endTime (%s) to be after startTime (%s)", endTime, startTime)
+		if endTime.Sub(startTime) < 0 {
+			t.Logf("Expected endTime (%s) to be >= startTime (%s)", endTime, startTime)
 			return false, nil
 		}
 

--- a/website/docs/3_configuration_deployment/5_sidecars.md
+++ b/website/docs/3_configuration_deployment/5_sidecars.md
@@ -84,7 +84,7 @@ With the above configuration, the following configuration will be added to the `
 ```
 
 :::info
-Note that all sidecars added with this configuration will be have, at the container init, some of environment variables from cassandra container merged with those defined into the sidecar container
+Note that all sidecars added with this configuration will have some of the environment variables from cassandra container merged with those defined into the sidecar container
 for example :
 
 - CASSANDRA_MAX_HEAP


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
This PR fixes a bug where the env CASSANDRA_MAX_HEAP is set based on that container resources instead of the main Cassandra container's resources.