### PR TITLE
[Feature/Operator] Share process namespace

### DIFF
--- a/deploy/crds/db.orange.com_cassandraclusters_crd.yaml
+++ b/deploy/crds/db.orange.com_cassandraclusters_crd.yaml
@@ -281,8 +281,9 @@ spec:
                   type: object
               type: object
             shareProcessNamespace:
-              description: When process namespace sharing is enabled, processes in
+              description: 'When process namespace sharing is enabled, processes in
                 a container are visible to all other containers in that pod. https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/
+                Optional: Default to false.'
               type: boolean
             sidecarConfigs:
               description: SidecarsConfig defines additional sidecar configurations

--- a/deploy/crds/db.orange.com_cassandraclusters_crd.yaml
+++ b/deploy/crds/db.orange.com_cassandraclusters_crd.yaml
@@ -280,6 +280,10 @@ spec:
                     headless service the CassKop operator creates
                   type: object
               type: object
+            shareProcessNamespace:
+              description: When process namespace sharing is enabled, processes in
+                a container are visible to all other containers in that pod. https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/
+              type: boolean
             sidecarConfigs:
               description: SidecarsConfig defines additional sidecar configurations
               items:

--- a/helm/cassandra-operator/readme.md
+++ b/helm/cassandra-operator/readme.md
@@ -25,7 +25,7 @@ The following tables lists the configurable parameters of the Cassandra Operator
 | `rbacEnable`                     | If true, create & use RBAC resources             | `true`                                    |
 | `resources`                      | Pod resource requests & limits                   | `{}`                                      |
 | `metricService`                  | deploy service for metrics                       | `false`                                   |
-| `debug.enabled`                  | activate DEBUG log level                         | `false`                                   |
+| `debug.enabled`                  | activate DEBUG log level and enable shareProcessNamespace (allowing ephemeral container usage) | `false`                                   |
 
 
 

--- a/helm/cassandra-operator/templates/deployment.yaml
+++ b/helm/cassandra-operator/templates/deployment.yaml
@@ -30,6 +30,9 @@ spec:
 {{- end }}
       securityContext:
         runAsUser: 1000
+{{- if .Values.debug.enabled }}
+      shareProcessNamespace: true
+{{- end }}
       containers:
       - name: {{ template "cassandra-operator.name" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -56,7 +59,7 @@ spec:
                 fieldPath: metadata.name
           - name: OPERATOR_NAME
             value: "cassandra-operator"
-{{- if .Values.debug.enable }}
+{{- if .Values.debug.enabled }}
           - name: LOG_LEVEL
             value: Debug
 {{- end }}

--- a/multi-casskop/helm/multi-casskop/readme.md
+++ b/multi-casskop/helm/multi-casskop/readme.md
@@ -28,7 +28,7 @@ The following tables lists the configurable parameters of the Cassandra Operator
 | `rbacEnable`                     | If true, create & use RBAC resources             | `true`                                    |
 | `resources`                      | Pod resource requests & limits                   | `{}`                                      |
 | `metricService`                  | deploy service for metrics                       | `false`                                   |
-| `debug.enabled`                  | activate DEBUG log level                         | `false`                                   |
+| `debug.enabled`                  | activate DEBUG log level  and enable shareProcessNamespace (allowing ephemeral container usage)                        | `false`                                   |
 
 
 

--- a/multi-casskop/helm/multi-casskop/templates/deployment.yaml
+++ b/multi-casskop/helm/multi-casskop/templates/deployment.yaml
@@ -30,6 +30,9 @@ spec:
 {{- end }}
       securityContext:
         runAsUser: 1000
+{{- if .Values.debug.enabled }}
+      shareProcessNamespace: true
+{{- end }}
       containers:
       - name: {{ template "multi-casskop.name" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -63,7 +66,7 @@ spec:
                 fieldPath: metadata.name
           - name: OPERATOR_NAME
             value: "multi-casskop"
-{{- if .Values.debug.enable }}
+{{- if .Values.debug.enabled }}
           - name: LOG_LEVEL
             value: Debug
 {{- end }}

--- a/pkg/apis/db/v1alpha1/cassandracluster_types.go
+++ b/pkg/apis/db/v1alpha1/cassandracluster_types.go
@@ -854,7 +854,10 @@ type CassandraClusterSpec struct {
 	ReadinessSuccessThreshold *int32 `json:"readinessSuccessThreshold,omitempty"`
 	// When process namespace sharing is enabled, processes in a container are visible to all other containers in that pod.
 	// https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/
-	ShareProcessNamespace bool `json:"shareProcessNamespace,omitempty"`
+	// Optional: Default to false.
+	// +k8s:conversion-gen=false
+	// +optional
+	ShareProcessNamespace *bool `json:"shareProcessNamespace,omitempty" protobuf:"varint,27,opt,name=shareProcessNamespace"`
 }
 
 // StorageConfig defines additional storage configurations

--- a/pkg/apis/db/v1alpha1/cassandracluster_types.go
+++ b/pkg/apis/db/v1alpha1/cassandracluster_types.go
@@ -852,6 +852,9 @@ type CassandraClusterSpec struct {
 	// ReadinessSuccessThreshold defines success threshold for the readiness probe of the main
 	// cassandra container : https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
 	ReadinessSuccessThreshold *int32 `json:"readinessSuccessThreshold,omitempty"`
+	// When process namespace sharing is enabled, processes in a container are visible to all other containers in that pod.
+	// https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/
+	ShareProcessNamespace bool `json:"shareProcessNamespace,omitempty"`
 }
 
 // StorageConfig defines additional storage configurations

--- a/pkg/apis/db/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/db/v1alpha1/zz_generated.deepcopy.go
@@ -177,6 +177,11 @@ func (in *CassandraClusterSpec) DeepCopyInto(out *CassandraClusterSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.ShareProcessNamespace != nil {
+		in, out := &in.ShareProcessNamespace, &out.ShareProcessNamespace
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controller/cassandracluster/generator.go
+++ b/pkg/controller/cassandracluster/generator.go
@@ -352,6 +352,7 @@ func generateCassandraStatefulSet(cc *api.CassandraCluster, status *api.Cassandr
 					Volumes:                       volumes,
 					RestartPolicy:                 v1.RestartPolicyAlways,
 					TerminationGracePeriodSeconds: &terminationPeriod,
+					ShareProcessNamespace:         &cc.Spec.ShareProcessNamespace,
 				},
 			},
 			VolumeClaimTemplates: volumeClaimTemplate,

--- a/pkg/controller/cassandracluster/generator.go
+++ b/pkg/controller/cassandracluster/generator.go
@@ -352,7 +352,7 @@ func generateCassandraStatefulSet(cc *api.CassandraCluster, status *api.Cassandr
 					Volumes:                       volumes,
 					RestartPolicy:                 v1.RestartPolicyAlways,
 					TerminationGracePeriodSeconds: &terminationPeriod,
-					ShareProcessNamespace:         &cc.Spec.ShareProcessNamespace,
+					ShareProcessNamespace:         cc.Spec.ShareProcessNamespace,
 				},
 			},
 			VolumeClaimTemplates: volumeClaimTemplate,

--- a/website/docs/3_configuration_deployment/1_customizable_install_with_helm.md
+++ b/website/docs/3_configuration_deployment/1_customizable_install_with_helm.md
@@ -27,7 +27,7 @@ The following tables lists the configurable parameters of the Cassandra Operator
 | `rbacEnable`                     | If true, create & use RBAC resources             | `true`                                    |
 | `resources`                      | Pod resource requests & limits                   | `{}`                                      |
 | `metricService`                  | deploy service for metrics                       | `false`                                   |
-| `debug.enabled`                  | activate DEBUG log level                         | `false`                                   |
+| `debug.enabled`                  | activate DEBUG log level  and enable shareProcessNamespace (allowing ephemeral container usage)                         | `false`                                   |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/website/docs/6_references/1_cassandra_cluster.md
+++ b/website/docs/6_references/1_cassandra_cluster.md
@@ -27,6 +27,7 @@ spec:
   autoUpdateSeedList: false
   maxPodUnavailable: 1
   runAsUser: 999
+  shareProcessNamespace: true
   resources:         
     requests:
       cpu: '1'
@@ -70,6 +71,8 @@ spec:
 |service|[ServicePolicy](#servicepolicy)||No|-|
 |deletePVC|bool|Defines if the PVC must be deleted when the cluster is deleted|Yes|false|
 |debug|bool|Is used to surcharge Cassandra pod command to not directly start cassandra but starts an infinite wait to allow user to connect a bash into the pod to make some diagnoses.|Yes|false|
+|shareProcessNamespace|bool|When process namespace sharing is enabled, processes in a container are visible to all other containers in that pod.
+                            	// https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/|Yes|false|
 |autoPilot|bool|Defines if the Operator can fly alone or if we need human action to trigger actions on specific Cassandra nodes. [Check documentation for more informations](/casskop/docs/5_operations/2_pods_operations)|Yes|false|
 |noCheckStsAreEqual|bool||Yes|false|
 |gcStdout|bool|Set the parameter CASSANDRA_GC_STDOUT which configure the JVM -Xloggc: true by default|Yes|true|


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

This PR adds the [shareProcessNamespace](https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/) to allow users: 

- `CassandraCluster.Spec` as a new field of the same name (if set to true, all cassandra pods will have this feature is enabled.
- CassKop and Multi-Casskop : now if you setup these operators using the helm chart with `debug.enabled` set to `true` it will enable this feature to the pod operator.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

This feature give the possibility to use [ephemeral containers](https://kubernetes.io/docs/concepts/workloads/pods/ephemeral-containers/) to debug cassandra nodes and operator.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [X] Logging code meets the guideline
- [X] User guide and development docs updated (if needed)