### PR TITLE
[Fix/Plugin] Remove metadata.resourceVersion from the applied resource

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,8 @@
 
 ### Bug Fixes
 
+- PR [#252](https://github.com/Orange-OpenSource/casskop/pull/252) - **[Plugin]** Remove metadata.resourceVersion from the applied resource
+
 
 ## 0.5.4
 

--- a/plugins/kubectl-casskop
+++ b/plugins/kubectl-casskop
@@ -30,6 +30,9 @@ RE_RACK_NAME = re.compile(r"(\w+)\W(\w+)")
 
 def k_apply_with_input(input, error, *args):
     try:
+        resource = json.loads(input)
+        del resource["metadata"]["resourceVersion"]
+        input = json.dumps(resource)
         check_output(["kubectl", "apply", "-f", "-"], stderr=STDOUT, input=str.encode(input))
     except CalledProcessError:
         die(error)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #251 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

This PR removes the `metadata.resourceVersion` field before applying the resource when the plugin is used.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Without this, once the plugin has performed an operation that requires an `apply`, we aren't able to apply the changes without removing the `metadata.annotations.kubectl.kubernetes.io/last-applied-configuration` field.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested
- [X] Logging code meets the guideline
- [X] User guide and development docs updated (if needed)
- [x] Append changelog