### PR TITLE
Unset RollingRestart flag before comparing CassandraCluster objects in MultiCasskop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ orbs:
       vm:
         machine:
           image: ubuntu-1604:201903-01
+        resource_class: large
     jobs:
       e2e-orb:
         # PARAMETERS
@@ -428,12 +429,12 @@ workflows:
             - build-casskop
           <<: *ignore_fork_pr_filter
 
-#      - k3d/e2e-orb:
-#          name: e2e-test ScaleDown
-#          test_name: ClusterScaleDown
-#          requires:
-#            - build-casskop
-#          <<: *ignore_fork_pr_filter
+      - k3d/e2e-orb:
+          name: e2e-test ScaleDown
+          test_name: ClusterScaleDown
+          requires:
+            - build-casskop
+          <<: *ignore_fork_pr_filter
 
       - k3d/e2e-orb:
           name: e2e-test ScaleDownSimple

--- a/multi-casskop/Makefile
+++ b/multi-casskop/Makefile
@@ -154,11 +154,7 @@ generate:
 	operator-sdk generate k8s
 
 .PHONY: build
-build:
-	@echo "Generate zzz-deepcopy objects"
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o build/_output/bin/health ../tools/health/main.go
-	operator-sdk version
-	operator-sdk generate k8s
+build: generate
 	@echo "Build Cassandra Operator"
 	operator-sdk build $(REPOSITORY):$(VERSION) --image-build-args "--build-arg https_proxy=$$https_proxy --build-arg http_proxy=$$http_proxy"
 ifdef PUSHLATEST
@@ -166,18 +162,15 @@ ifdef PUSHLATEST
 endif
 #
 
-build-local:
-	@echo "Generate zzz-deepcopy objects"
-	operator-sdk version
-	operator-sdk generate k8s
+build-local: generate
 	@echo "Build Cassandra Operator for $(GOOS)"
 	go build -o build/_output/bin/multi-casskop-$(GOOS) -gcflags all=-trimpath=github.com/Orange-OpenSource -asmflags all=-trimpath=github.com/Orange-OpenSource github.com/Orange-OpenSource/casskop/multi-casskop/cmd/manager
 
 debug-telepresence:
 	export TELEPRESENCE_REGISTRY=$(TELEPRESENCE_REGISTRY) ; \
 	echo "execute : cat multi-casskop.env" ; \
-  sudo mkdir -p /var/run/secrets/kubernetes.io ; \
-  sudo mkdir -p /var/run/secrets/admiralty.io ; \
+	sudo mkdir -p /var/run/secrets/kubernetes.io ; \
+	sudo mkdir -p /var/run/secrets/admiralty.io ; \
 	sudo ln -s /tmp/known/var/run/secrets/kubernetes.io/serviceaccount /var/run/secrets/kubernetes.io/ ; \
 	sudo ln -s /tmp/known/var/run/secrets/admiralty.io/serviceaccountimports /var/run/secrets/admiralty.io/ ; \
 	tdep=$(shell kubectl get deployment -l app=multi-casskop -o jsonpath='{.items[0].metadata.name}') ; \

--- a/multi-casskop/Makefile
+++ b/multi-casskop/Makefile
@@ -145,18 +145,44 @@ helm-package:
 export CGO_ENABLED:=0
 export PURE:="on"
 
+DOCKER_BUILD = docker run --rm -v $(PWD)/..:$(WORKDIR) -v $(GOPATH)/pkg/mod:/go/pkg/mod:delegated \
+               		-v /var/run/docker.sock:/var/run/docker.sock \
+               		-v $(shell go env GOCACHE):/root/.cache/go-build:delegated \
+               		--env CGO_ENABLED=$(CGO_ENABLED) --env GOOS=linux --env GOARCH=amd64 \
+               		--env https_proxy=$(https_proxy) --env http_proxy=$(http_proxy) \
+               		$(BUILD_IMAGE):$(OPERATOR_SDK_VERSION) /bin/bash -c
+
+MULTI_CASSKOP = cd multi-casskop
+GENERATE_CMD = CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GOARCH=amd64 go build -o build/_output/bin/health \
+				 ../tools/health/main.go
+GENERATE_K8S = operator-sdk generate k8s
+BUILD_CMD = operator-sdk build $(REPOSITORY):$(VERSION) --image-build-args \
+				"--build-arg https_proxy=$$https_proxy --build-arg http_proxy=$$http_proxy"
+
+docker-generate-k8s:
+	echo "Generate zzz-deepcopy objects"
+	$(DOCKER_BUILD) '$(MULTI_CASSKOP); $(GENERATE_CMD)'
+	$(DOCKER_BUILD) '$(MULTI_CASSKOP); $(GENERATE_K8S)'
+
+docker-build-operator:
+	echo "Build Cassandra Operator. Using cache from "$(shell go env GOCACHE)
+	$(DOCKER_BUILD) '$(MULTI_CASSKOP); $(BUILD_CMD)'
+
+# Build the Operator and its Docker Image
+docker-build: docker-generate-k8s docker-build-operator
+
 .PHONY: generate
 generate:
 	@echo "Generate zzz-deepcopy objects"
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o build/_output/bin/health ../tools/health/main.go
+	$(GENERATE_CMD)
 	echo "Generate zzz-deepcopy objects"
 	operator-sdk version
-	operator-sdk generate k8s
+	$(GENERATE_K8S)
 
 .PHONY: build
 build: generate
 	@echo "Build Cassandra Operator"
-	operator-sdk build $(REPOSITORY):$(VERSION) --image-build-args "--build-arg https_proxy=$$https_proxy --build-arg http_proxy=$$http_proxy"
+	$(BUILD_CMD)
 ifdef PUSHLATEST
 	docker tag $(REPOSITORY):$(VERSION) $(REPOSITORY):latest
 endif
@@ -199,7 +225,6 @@ run-local:
 	export WATCH_NAMESPACE=$(NAMESPACE); \
 	export LOG_LEVEL=Debug; \
 	./build/_output/bin/multi-casskop-$(GOOS) $(RUN_ARGS)
-
 
 .PHONY: push
 push:

--- a/multi-casskop/Readme.md
+++ b/multi-casskop/Readme.md
@@ -94,7 +94,7 @@ $ helm repo update
 Connect to each kubernetes you want to deploy your Cassandra clusters to and install CassKop:
 
 ```console
-$ helm install --name casskop orange-incubator/cassandra-operator
+$ helm install casskop orange-incubator/cassandra-operator
 ```
 
 ### Install External-DNS
@@ -113,7 +113,7 @@ Proceed with Multi-CassKop installation only when [Pre-requisites](#pre-requisit
 Deployment with Helm. Multi-CassKop and CassKop shared the same github/helm repo and semantic version.
 
 ```
-helm install --name multi-casskop orange-incubator/multi-casskop --set k8s.local=k8s-cluster1 --set k8s.remote={k8s-cluster2}
+helm install multi-casskop orange-incubator/multi-casskop --set k8s.local=k8s-cluster1 --set k8s.remote={k8s-cluster2}
 ```
 
 > if you get an error complaining that the CRD already exists, then replay it with `--no-hooks`

--- a/multi-casskop/helm/multi-casskop/templates/role.yaml
+++ b/multi-casskop/helm/multi-casskop/templates/role.yaml
@@ -12,8 +12,8 @@ rules:
 - apiGroups:
   - db.orange.com
   resources:
-    - "multicasskops"
-    - "cassandraclusters"
+    - multicasskops
+    - cassandraclusters
   verbs:
     - create
     - delete

--- a/multi-casskop/pkg/controller/multi-casskop/cmc_utils.go
+++ b/multi-casskop/pkg/controller/multi-casskop/cmc_utils.go
@@ -52,6 +52,9 @@ func (r *reconciler) CreateOrUpdateCassandraCluster(client *models.Client,
 	}
 
 	needUpdate := false
+
+	UnsetRollingRestart(storedCC)
+
 	//TODO: need new way to detect changes
 	if !apiequality.Semantic.DeepEqual(storedCC.Spec, cc.Spec) {
 		logrus.WithFields(logrus.Fields{"cluster": cc.Name, "namespace": cc.Namespace, "kubernetes": client.Name}).
@@ -76,6 +79,14 @@ func (r *reconciler) CreateOrUpdateCassandraCluster(client *models.Client,
 		return true, newCC, err
 	}
 	return false, storedCC, nil
+}
+
+func UnsetRollingRestart(storedCC *ccv1.CassandraCluster) {
+	for _, dc := range storedCC.Spec.Topology.DC {
+		for _, rack := range dc.Rack {
+			rack.RollingRestart = false
+		}
+	}
 }
 
 func (r *reconciler) CreateCassandraCluster(client *models.Client, cc *ccv1.CassandraCluster) (*ccv1.CassandraCluster, error) {

--- a/multi-casskop/pkg/controller/multi-casskop/cmc_utils.go
+++ b/multi-casskop/pkg/controller/multi-casskop/cmc_utils.go
@@ -21,20 +21,6 @@ func (r *reconciler) ReadyCassandraCluster(cc *ccv1.CassandraCluster) bool {
 	return true
 }
 
-/*
-func (r *reconciler) GetCassandraCluster(client *Client, cc *ccv1.CassandraCluster) (*ccv1.CassandraCluster, error) {
-
-	storedCC := &ccv1.CassandraCluster{}
-	if err := client.client.Get(context.TODO(), r.namespacedName(cc.Name, cc.Namespace), storedCC); err != nil {
-		if errors.IsNotFound(err) {
-			logrus.WithFields(logrus.Fields{"cluster": cc.Name, "namespace": cc.Namespace, "kubernetes": client.name}).Debug("CassandraCluster don't exists, we create it ")
-			return nil, err
-		}
-		return storedCC, err
-	}
-}
-*/
-
 // CreateOrUpdateCassandraCluster
 // create CassandraCluster object in target kubernetes cluster if not exists
 // update it if it already exist
@@ -44,7 +30,8 @@ func (r *reconciler) CreateOrUpdateCassandraCluster(client *models.Client,
 
 	if err := client.Client.Get(context.TODO(), r.namespacedName(cc.Name, cc.Namespace), storedCC); err != nil {
 		if errors.IsNotFound(err) {
-			logrus.WithFields(logrus.Fields{"cluster": cc.Name, "namespace": cc.Namespace, "kubernetes": client.Name}).Debug("CassandraCluster don't exists, we create it ")
+			logrus.WithFields(logrus.Fields{"cluster": cc.Name, "namespace": cc.Namespace,
+				"kubernetes": client.Name}).Debug("CassandraCluster don't exists, we create it ")
 			newCC, err := r.CreateCassandraCluster(client, cc)
 			return true, newCC, err
 		}

--- a/multi-casskop/pkg/controller/multi-casskop/cmc_utils.go
+++ b/multi-casskop/pkg/controller/multi-casskop/cmc_utils.go
@@ -76,20 +76,26 @@ func UnsetRollingRestart(storedCC *ccv1.CassandraCluster) {
 	}
 }
 
-func (r *reconciler) CreateCassandraCluster(client *models.Client, cc *ccv1.CassandraCluster) (*ccv1.CassandraCluster, error) {
+func (r *reconciler) CreateCassandraCluster(client *models.Client,
+	cc *ccv1.CassandraCluster) (*ccv1.CassandraCluster, error) {
 	var err error
-	logrus.WithFields(logrus.Fields{"cluster": cc.Name, "namespace": cc.Namespace, "kubernetes": client.Name}).Debug("Create CassandraCluster")
+	logrus.WithFields(logrus.Fields{"cluster": cc.Name, "namespace": cc.Namespace, "kubernetes": client.Name}).Debug(
+		"Create CassandraCluster")
 	if err = client.Client.Create(context.TODO(), cc); err != nil {
 		if errors.IsAlreadyExists(err) {
+			logrus.WithFields(logrus.Fields{"cluster": cc.Name, "namespace": cc.Namespace,
+				"kubernetes": client.Name}).Debug("CassandraCluster already exists !")
 			return cc, nil
 		}
 	}
 	return cc, err
 }
 
-func (r *reconciler) UpdateCassandraCluster(client *models.Client, cc *ccv1.CassandraCluster) (*ccv1.CassandraCluster, error) {
+func (r *reconciler) UpdateCassandraCluster(client *models.Client,
+	cc *ccv1.CassandraCluster) (*ccv1.CassandraCluster, error) {
 	var err error
-	logrus.WithFields(logrus.Fields{"cluster": cc.Name, "namespace": cc.Namespace, "kubernetes": client.Name}).Debug("Update CassandraCluster")
+	logrus.WithFields(logrus.Fields{"cluster": cc.Name, "namespace": cc.Namespace, "kubernetes": client.Name}).Debug(
+		"Update CassandraCluster")
 	if err = client.Client.Update(context.TODO(), cc); err != nil {
 		if errors.IsAlreadyExists(err) {
 			return cc, nil

--- a/multi-casskop/pkg/controller/multi-casskop/cmc_utils.go
+++ b/multi-casskop/pkg/controller/multi-casskop/cmc_utils.go
@@ -69,9 +69,10 @@ func (r *reconciler) CreateOrUpdateCassandraCluster(client *models.Client,
 }
 
 func UnsetRollingRestart(storedCC *ccv1.CassandraCluster) {
-	for _, dc := range storedCC.Spec.Topology.DC {
-		for _, rack := range dc.Rack {
-			rack.RollingRestart = false
+	DC := (*storedCC).Spec.Topology.DC
+	for dcID := range DC {
+		for rackID := range DC[dcID].Rack {
+			DC[dcID].Rack[rackID].RollingRestart = false
 		}
 	}
 }

--- a/multi-casskop/pkg/controller/multi-casskop/cmc_utils.go
+++ b/multi-casskop/pkg/controller/multi-casskop/cmc_utils.go
@@ -31,7 +31,7 @@ func (r *reconciler) CreateOrUpdateCassandraCluster(client *models.Client,
 	if err := client.Client.Get(context.TODO(), r.namespacedName(cc.Name, cc.Namespace), storedCC); err != nil {
 		if errors.IsNotFound(err) {
 			logrus.WithFields(logrus.Fields{"cluster": cc.Name, "namespace": cc.Namespace,
-				"kubernetes": client.Name}).Debug("CassandraCluster don't exists, we create it ")
+				"kubernetes": client.Name}).Debug("CassandraCluster does not exist, we create it ")
 			newCC, err := r.CreateCassandraCluster(client, cc)
 			return true, newCC, err
 		}

--- a/multi-casskop/pkg/controller/multi-casskop/multi-casskop_controller.go
+++ b/multi-casskop/pkg/controller/multi-casskop/multi-casskop_controller.go
@@ -152,14 +152,15 @@ func (r *reconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) 
 		}
 		if update {
 			logrus.WithFields(logrus.Fields{"cluster": cc.Name, "namespace": cc.Namespace,
-				"kubernetes": client.Name}).Infof("Just Update CassandraCluster, returning for now..")
+				"kubernetes": client.Name}).Infof("CassandraCluster created/updated, returning for now..")
 			return requeue30, err
 		}
 
 		if !r.ReadyCassandraCluster(storedCC) {
 			logrus.WithFields(logrus.Fields{"cluster": cc.Name, "namespace": cc.Namespace,
 				"kubernetes": client.Name}).Infof("Cluster is not Ready, "+
-				"we requeue [phase=%s / action=%s / status=%s]", storedCC.Status.Phase, storedCC.Status.LastClusterAction, storedCC.Status.LastClusterActionStatus)
+				"we requeue [phase=%s / action=%s / status=%s]", storedCC.Status.Phase,
+				storedCC.Status.LastClusterAction, storedCC.Status.LastClusterActionStatus)
 			return requeue30, err
 		}
 	}

--- a/multi-casskop/pkg/controller/multi-casskop/multi-casskop_controller.go
+++ b/multi-casskop/pkg/controller/multi-casskop/multi-casskop_controller.go
@@ -59,14 +59,16 @@ func NewController(clusters models.Clusters, namespace string) (*controller.Cont
 	}
 
 	// Configure watch for MultiCassKop on Local only
-	if err := co.WatchResourceReconcileObject(context.TODO(), clusters.Local.Cluster, &cmcv1.MultiCasskop{ObjectMeta: metav1.ObjectMeta{Namespace: namespace}},
+	if err := co.WatchResourceReconcileObject(context.TODO(), clusters.Local.Cluster,
+		&cmcv1.MultiCasskop{ObjectMeta: metav1.ObjectMeta{Namespace: namespace}},
 		controller.WatchOptions{Namespace: namespace}); err != nil {
 		return nil, fmt.Errorf("setting up MultiCasskop watch in Cluster %s Cluster: %v", clusters.Local.Name, err)
 	}
 
 	// Configure watch for CassandraCluster on remote (
 	for _, cluster := range clusters.Remotes {
-		if err := co.WatchResourceReconcileObject(context.TODO(), cluster.Cluster, &ccv1.CassandraCluster{ObjectMeta: metav1.ObjectMeta{Namespace: namespace}},
+		if err := co.WatchResourceReconcileObject(context.TODO(), cluster.Cluster,
+			&ccv1.CassandraCluster{ObjectMeta: metav1.ObjectMeta{Namespace: namespace}},
 			controller.WatchOptions{Namespace: namespace}); err != nil {
 			return nil, fmt.Errorf("setting up MultiCasskop watch in Cluster %s Cluster: %v", clusters.Local.Name, err)
 		}

--- a/multi-casskop/pkg/controller/multi-casskop/multi-casskop_controller.go
+++ b/multi-casskop/pkg/controller/multi-casskop/multi-casskop_controller.go
@@ -124,12 +124,10 @@ func (r *reconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) 
 		return requeue, err
 	}
 
-	if ok := r.updateDeletetrategy(); ok == true {
+	if r.updateDeletetrategy() == true {
 		err := localClient.Update(context.TODO(), r.cmc)
 		return requeue, err
 	}
-
-	//var storedCC *ccv1.CassandraCluster`
 
 	// For all clients (local & remotes)
 	clients := r.clients.FlatClients()

--- a/multi-casskop/pkg/controller/multi-casskop/multi-casskop_controller.go
+++ b/multi-casskop/pkg/controller/multi-casskop/multi-casskop_controller.go
@@ -66,7 +66,7 @@ func NewController(clusters models.Clusters, namespace string) (*controller.Cont
 			clusters.Local.Name, err)
 	}
 
-	// Configure watch for CassandraCluster on remote (
+	// Configure watch for CassandraCluster on all sites (
 	for _, cluster := range append(clusters.Remotes, clusters.Local) {
 		if err := co.WatchResourceReconcileObject(context.TODO(), cluster.Cluster,
 			&ccv1.CassandraCluster{ObjectMeta: metav1.ObjectMeta{Namespace: namespace}},

--- a/multi-casskop/pkg/controller/multi-casskop/multi-casskop_controller.go
+++ b/multi-casskop/pkg/controller/multi-casskop/multi-casskop_controller.go
@@ -62,15 +62,16 @@ func NewController(clusters models.Clusters, namespace string) (*controller.Cont
 	if err := co.WatchResourceReconcileObject(context.TODO(), clusters.Local.Cluster,
 		&cmcv1.MultiCasskop{ObjectMeta: metav1.ObjectMeta{Namespace: namespace}},
 		controller.WatchOptions{Namespace: namespace}); err != nil {
-		return nil, fmt.Errorf("setting up MultiCasskop watch in Cluster %s Cluster: %v", clusters.Local.Name, err)
+		return nil, fmt.Errorf("setting up MultiCasskop watch in Cluster %s Cluster: %v",
+			clusters.Local.Name, err)
 	}
 
 	// Configure watch for CassandraCluster on remote (
-	for _, cluster := range clusters.Remotes {
+	for _, cluster := range append(clusters.Remotes, clusters.Local) {
 		if err := co.WatchResourceReconcileObject(context.TODO(), cluster.Cluster,
 			&ccv1.CassandraCluster{ObjectMeta: metav1.ObjectMeta{Namespace: namespace}},
 			controller.WatchOptions{Namespace: namespace}); err != nil {
-			return nil, fmt.Errorf("setting up MultiCasskop watch in Cluster %s Cluster: %v", clusters.Local.Name, err)
+			return nil, fmt.Errorf("setting up MultiCasskop watch in Cluster %s Cluster: %v", cluster.Name, err)
 		}
 	}
 	return co, nil

--- a/pkg/apis/db/v1alpha1/cassandracluster_types.go
+++ b/pkg/apis/db/v1alpha1/cassandracluster_types.go
@@ -974,7 +974,7 @@ type CassandraClusterStatus struct {
 	// Indicates if we need to paused specific actions
 	//ActionPaused bool `json:"actionPaused,omitempty"`
 
-	//seeList to be used in Cassandra's Pods (computed by the Operator)
+	//seedList to be used in Cassandra's Pods (computed by the Operator)
 	SeedList []string `json:"seedlist,omitempty"`
 
 	//

--- a/pkg/controller/cassandracluster/cassandra_status.go
+++ b/pkg/controller/cassandracluster/cassandra_status.go
@@ -102,6 +102,7 @@ func (rcc *ReconcileCassandraCluster) getNextCassandraClusterStatus(cc *api.Cass
 	// decommission more
 	// We don't want to check for new operation while there are already ongoing one in order not to break them (ie decommission..)
 	// Meanwhile we allow to check for new changes if unlockNextOperation	 has been set (to recover from problems)
+
 	if unlockNextOperation ||
 		(rcc.hasNoPodDisruption() &&
 			lastAction.Status != api.StatusOngoing &&

--- a/pkg/controller/cassandracluster/cassandra_status.go
+++ b/pkg/controller/cassandracluster/cassandra_status.go
@@ -103,7 +103,7 @@ func (rcc *ReconcileCassandraCluster) getNextCassandraClusterStatus(cc *api.Cass
 	// We don't want to check for new operation while there are already ongoing one in order not to break them (ie decommission..)
 	// Meanwhile we allow to check for new changes if unlockNextOperation	 has been set (to recover from problems)
 	if unlockNextOperation ||
-		(!rcc.thereIsPodDisruption() &&
+		(rcc.hasNoPodDisruption() &&
 			lastAction.Status != api.StatusOngoing &&
 			lastAction.Status != api.StatusToDo &&
 			lastAction.Status != api.StatusFinalizing) {

--- a/pkg/controller/cassandracluster/cassandra_util.go
+++ b/pkg/controller/cassandracluster/cassandra_util.go
@@ -22,9 +22,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-//thereIsNoPodDisruption return true if there is no Disruption in the Pods of the cassandra Cluster
-func (rcc *ReconcileCassandraCluster) thereIsPodDisruption() bool {
-
+//hasNoPodDisruption return true if there is no Disruption in the Pods of the cassandra Cluster
+func (rcc *ReconcileCassandraCluster) hasNoPodDisruption() bool {
 	return rcc.storedPdb.Status.DisruptionsAllowed == 0
 }
 

--- a/pkg/controller/cassandracluster/cassandra_util.go
+++ b/pkg/controller/cassandracluster/cassandra_util.go
@@ -24,15 +24,8 @@ import (
 
 //hasNoPodDisruption return true if there is no Disruption in the Pods of the cassandra Cluster
 func (rcc *ReconcileCassandraCluster) hasNoPodDisruption() bool {
-	return rcc.storedPdb.Status.DisruptionsAllowed == 0
-}
-
-func (rcc *ReconcileCassandraCluster) allowMoreThan1PodDisruption() bool {
-	return rcc.storedPdb.Spec.MaxUnavailable.IntVal > 1
-}
-
-func (rcc *ReconcileCassandraCluster) hasOneDisruptedPod() bool {
-	return (rcc.storedPdb.Status.DesiredHealthy+rcc.storedPdb.Spec.MaxUnavailable.IntVal)-rcc.storedPdb.Status.CurrentHealthy > 0
+	status := rcc.storedPdb.Status
+	return status.DesiredHealthy-status.CurrentHealthy <= rcc.storedPdb.Spec.MaxUnavailable.IntVal
 }
 
 //weAreScalingDown return true if we are Scaling Down the provided dc-rack

--- a/pkg/controller/cassandracluster/statefulset.go
+++ b/pkg/controller/cassandracluster/statefulset.go
@@ -203,15 +203,13 @@ func (rcc *ReconcileCassandraCluster) CreateOrUpdateStatefulSet(statefulSet *app
 	//We will not Update the Statefulset
 	// if there is existing disruptions on Pods
 	// Or if we are not scaling Down the current statefulset
-	if rcc.thereIsPodDisruption() {
+	if !rcc.hasNoPodDisruption() {
 		if rcc.cc.Spec.UnlockNextOperation {
-			logrus.WithFields(logrus.Fields{"cluster": rcc.cc.Name,
-				"dc-rack": dcRackName}).Warn("Cluster has a disruption " +
-				"but we have unlock the next operation")
+			logrus.WithFields(logrus.Fields{"cluster": rcc.cc.Name, "dc-rack": dcRackName}).Warn(
+				"Cluster has a disruption but we have unlock the next operation")
 		} else {
-			logrus.WithFields(logrus.Fields{"cluster": rcc.cc.Name,
-				"dc-rack": dcRackName}).Info("Cluster has a disruption, " +
-				"waiting before applying any changes to statefulset")
+			logrus.WithFields(logrus.Fields{"cluster": rcc.cc.Name, "dc-rack": dcRackName}).Info(
+				"Cluster has a disruption, waiting before applying any changes to statefulset")
 			return api.ContinueResyncLoop, nil
 		}
 	}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | []
| API breaks?     | []
| Deprecations?   | []
| License         | Apache 2.0

MultiCasskop prevents a rolling restart by rollbacking the change when it sees the flag RollingRestart being set