### PR TITLE
Fix joloika auth

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,8 @@
 
 ### Bug Fixes
 
+- PR [#273](https://github.com/Orange-OpenSource/casskop/pull/273) - **[CassandraCluster]** Fix Jolokia auth.
+
 ## v1.0.0
 
 ### Added

--- a/docker/bootstrap/Makefile
+++ b/docker/bootstrap/Makefile
@@ -19,7 +19,7 @@ else
 	PROJECT:=$(CI_REGISTRY_IMAGE)
 endif
 
-VERSION:=0.1.5
+VERSION:=0.1.6
 TAG?=${VERSION}
 ifeq ($(CIRCLE_BRANCH),master)
 	BRANCH:=latest

--- a/docker/bootstrap/files/readiness-probe.sh
+++ b/docker/bootstrap/files/readiness-probe.sh
@@ -14,8 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Add Jolokia credentials, if defined in environment.
+if [[ -z $JOLOKIA_USER ]] || [[ -z $JOLOKIA_PASSWORD ]]; then
+    USER_OPT=""
+else
+    USER_OPT="--user $JOLOKIA_USER:$JOLOKIA_PASSWORD"
+fi
+
 # We check when the node is up and in normal state
-CURL="/opt/bin/curl -s --connect-timeout 0.5"
+CURL="/opt/bin/curl $USER_OPT -s --connect-timeout 0.5"
 BASE_CMD="http://$POD_IP:8778/jolokia/read/org.apache.cassandra.db:type=StorageService"
 
 if $CURL ${BASE_CMD}/LiveNodes | grep -q $POD_IP; then

--- a/docker/bootstrap/files/readiness-probe.sh
+++ b/docker/bootstrap/files/readiness-probe.sh
@@ -15,9 +15,7 @@
 # limitations under the License.
 
 # Add Jolokia credentials, if defined in environment.
-if [[ -z $JOLOKIA_USER ]] || [[ -z $JOLOKIA_PASSWORD ]]; then
-    USER_OPT=""
-else
+if [[ -n $JOLOKIA_USER ]] && [[ -n $JOLOKIA_PASSWORD ]]; then
     USER_OPT="--user $JOLOKIA_USER:$JOLOKIA_PASSWORD"
 fi
 

--- a/pkg/apis/db/v1alpha1/cassandracluster_types.go
+++ b/pkg/apis/db/v1alpha1/cassandracluster_types.go
@@ -35,7 +35,7 @@ const (
 	DefaultReadinessHealthCheckPeriod   int32 = 10
 
 	defaultCassandraImage         = "cassandra:3.11"
-	defaultBootstrapImage         = "orangeopensource/cassandra-bootstrap:0.1.5"
+	defaultBootstrapImage         = "orangeopensource/cassandra-bootstrap:0.1.6"
 	defaultServiceAccountName     = "cassandra-cluster-node"
 	InitContainerCmd              = "cp -vr /etc/cassandra/* /bootstrap"
 	defaultMaxPodUnavailable      = 1

--- a/pkg/controller/cassandracluster/generator.go
+++ b/pkg/controller/cassandracluster/generator.go
@@ -596,10 +596,6 @@ func bootstrapContainerEnvVar(cc *api.CassandraCluster, status *api.CassandraClu
 	return bootstrapEnvVars
 }
 
-func cassandraContainerEnvVar(cc *api.CassandraCluster) []v1.EnvVar {
-	return commonBootstrapCassandraEnvVar(cc)
-}
-
 func commonBootstrapCassandraEnvVar(cc *api.CassandraCluster) []v1.EnvVar {
 	commonEnvVars := []v1.EnvVar{
 		{
@@ -768,7 +764,7 @@ func createCassandraContainer(cc *api.CassandraCluster, status *api.CassandraClu
 				},
 			},
 		},
-		Env: cassandraContainerEnvVar(cc),
+		Env: commonBootstrapCassandraEnvVar(cc),
 		ReadinessProbe: &v1.Probe{
 			InitialDelaySeconds: *cc.Spec.ReadinessInitialDelaySeconds,
 			TimeoutSeconds:      *cc.Spec.ReadinessHealthCheckTimeout,

--- a/pkg/controller/cassandracluster/generator.go
+++ b/pkg/controller/cassandracluster/generator.go
@@ -378,35 +378,6 @@ func generateCassandraStatefulSet(cc *api.CassandraCluster, status *api.Cassandr
 		}
 	}
 
-	for idx, container := range ss.Spec.Template.Spec.Containers {
-		if container.Name == cassandraContainerName {
-			if (cc.Spec.ImageJolokiaSecret != v1.LocalObjectReference{}) {
-				ss.Spec.Template.Spec.Containers[idx].Env = append(container.Env,
-					v1.EnvVar{
-						Name: "JOLOKIA_USER",
-						ValueFrom: &v1.EnvVarSource{
-							SecretKeyRef: &v1.SecretKeySelector{
-								LocalObjectReference: cc.Spec.ImageJolokiaSecret,
-								Key:                  "username",
-							},
-						},
-					},
-					v1.EnvVar{
-						Name: "JOLOKIA_PASSWORD",
-						ValueFrom: &v1.EnvVarSource{
-							SecretKeyRef: &v1.SecretKeySelector{
-								LocalObjectReference: cc.Spec.ImageJolokiaSecret,
-								Key:                  "password",
-							},
-						},
-					},
-					v1.EnvVar{
-						Name:  "CASSANDRA_AUTH_JOLOKIA",
-						Value: "true"})
-			}
-		}
-	}
-
 	// Merge cassandra main container environment variables into sidecars.
 
 	var sidecarEnv []v1.EnvVar
@@ -580,8 +551,7 @@ func bootstrapContainerEnvVar(cc *api.CassandraCluster, status *api.CassandraClu
 	//in statefulset.go we surcharge this value with conditions
 	seedList := cc.SeedList(&status.SeedList)
 	numTokensPerRacks := cc.NumTokensPerRacks(dcRackName)
-
-	return []v1.EnvVar{
+	bootstrapEnvVars := []v1.EnvVar{
 		{
 			Name:  "CASSANDRA_MAX_HEAP",
 			Value: defineJvmMemory(resources).maxHeapSize,
@@ -593,15 +563,6 @@ func bootstrapContainerEnvVar(cc *api.CassandraCluster, status *api.CassandraClu
 		{
 			Name:  "CASSANDRA_CLUSTER_NAME",
 			Value: name,
-		},
-		{
-			Name: "POD_IP",
-			ValueFrom: &v1.EnvVarSource{
-				FieldRef: &v1.ObjectFieldSelector{
-					APIVersion: "v1",
-					FieldPath:  "status.podIP",
-				},
-			},
 		},
 		{
 			Name:  "CASSANDRA_GC_STDOUT",
@@ -630,6 +591,55 @@ func bootstrapContainerEnvVar(cc *api.CassandraCluster, status *api.CassandraClu
 			},
 		},
 	}
+	commonEnvVars := commonBootstrapCassandraEnvVar(cc)
+	bootstrapEnvVars = append(bootstrapEnvVars, commonEnvVars...)
+	return bootstrapEnvVars
+}
+
+func cassandraContainerEnvVar(cc *api.CassandraCluster) []v1.EnvVar {
+	return commonBootstrapCassandraEnvVar(cc)
+}
+
+func commonBootstrapCassandraEnvVar(cc *api.CassandraCluster) []v1.EnvVar {
+	commonEnvVars := []v1.EnvVar{
+		{
+			Name: "POD_IP",
+			ValueFrom: &v1.EnvVarSource{
+				FieldRef: &v1.ObjectFieldSelector{
+					APIVersion: "v1",
+					FieldPath:  "status.podIP",
+				},
+			},
+		},
+	}
+	if (cc.Spec.ImageJolokiaSecret != v1.LocalObjectReference{}) {
+		jolokiaEnvVars := []v1.EnvVar{
+			{
+				Name: "JOLOKIA_USER",
+				ValueFrom: &v1.EnvVarSource{
+					SecretKeyRef: &v1.SecretKeySelector{
+						LocalObjectReference: cc.Spec.ImageJolokiaSecret,
+						Key:                  "username",
+					},
+				},
+			},
+			{
+				Name: "JOLOKIA_PASSWORD",
+				ValueFrom: &v1.EnvVarSource{
+					SecretKeyRef: &v1.SecretKeySelector{
+						LocalObjectReference: cc.Spec.ImageJolokiaSecret,
+						Key:                  "password",
+					},
+				},
+			},
+			{
+				Name:  "CASSANDRA_AUTH_JOLOKIA",
+				Value: "true",
+			},
+		}
+		commonEnvVars = append(commonEnvVars, jolokiaEnvVars...)
+	}
+	return commonEnvVars
 }
 
 // createInitConfigContainer allows to copy origin config files from init-config container to /bootstrap directory
@@ -758,17 +768,7 @@ func createCassandraContainer(cc *api.CassandraCluster, status *api.CassandraClu
 				},
 			},
 		},
-		Env: []v1.EnvVar{
-			{
-				Name: "POD_IP",
-				ValueFrom: &v1.EnvVarSource{
-					FieldRef: &v1.ObjectFieldSelector{
-						APIVersion: "v1",
-						FieldPath:  "status.podIP",
-					},
-				},
-			},
-		},
+		Env: cassandraContainerEnvVar(cc),
 		ReadinessProbe: &v1.Probe{
 			InitialDelaySeconds: *cc.Spec.ReadinessInitialDelaySeconds,
 			TimeoutSeconds:      *cc.Spec.ReadinessHealthCheckTimeout,

--- a/pkg/controller/cassandracluster/generator_test.go
+++ b/pkg/controller/cassandracluster/generator_test.go
@@ -499,6 +499,18 @@ func checkVarEnv(t *testing.T, containers []v1.Container, cc *api.CassandraClust
 				assert.Contains(envVar, env.Name)
 				assert.Equal(envVar[env.Name], env.Value)
 			}
+		} else {
+			// Check cassandra container env vars
+			podIP := v1.EnvVar{
+				Name: "POD_IP",
+				ValueFrom: &v1.EnvVarSource{
+					FieldRef: &v1.ObjectFieldSelector{
+						APIVersion: "v1",
+						FieldPath:  "status.podIP",
+					},
+				},
+			}
+			assert.Contains(container.Env, podIP)
 		}
 	}
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | []
| API breaks?     | []
| Deprecations?   | []
| Related tickets | fixes #270
| License         | Apache 2.0


### What's in this PR?
This PR adds JOLOKIA env vars to the bootstrap container.

The JOLOKIA env vars must be set in the bootstrap container in order for run.sh to enable auth for Jolokia. And, they also need to be set in the cassandra container, so that readiness-probe.sh can use the credentials when required.


### Additional context
I'd like to add a unit test to check for JOLOKIA env vars, but I'm not sure how to set a `jolokia-auth` secret in the unit tests. Happy to add that if you can give me guidance on how I could do that.

I did confirm that unit tests pass, and the env vars are set as expected in both the bootstrap and cassandra containers when running the controller.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Append changelog

