### PR TITLE
liveness - Make separate liveness/readiness probes possible.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ DOCKER_REPO_BASE_TEST ?= orangeopensource
 IMAGE_NAME := $(SERVICE_NAME)
 BUILD_IMAGE ?= orangeopensource/casskop-build
 
-BOOTSTRAP_IMAGE ?= orangeopensource/cassandra-bootstrap:0.1.4
+BOOTSTRAP_IMAGE ?= orangeopensource/cassandra-bootstrap:0.1.7
 TELEPRESENCE_REGISTRY ?= datawire
 KUBESQUASH_REGISTRY:=
 

--- a/docker/bootstrap/Makefile
+++ b/docker/bootstrap/Makefile
@@ -19,7 +19,7 @@ else
 	PROJECT:=$(CI_REGISTRY_IMAGE)
 endif
 
-VERSION:=0.1.6
+VERSION:=0.1.7
 TAG?=${VERSION}
 ifeq ($(CIRCLE_BRANCH),master)
 	BRANCH:=latest

--- a/docker/bootstrap/dgoss/checks/goss.yaml
+++ b/docker/bootstrap/dgoss/checks/goss.yaml
@@ -70,6 +70,9 @@ file:
   /etc/cassandra/pre_run.sh:
     exists: false
 
+  /etc/cassandra/liveness-probe.sh:
+    exists: true
+
   /etc/cassandra/readiness-probe.sh:
     exists: true
 

--- a/docker/bootstrap/dgoss/test-without-volumes/goss.yaml
+++ b/docker/bootstrap/dgoss/test-without-volumes/goss.yaml
@@ -40,6 +40,9 @@ file:
   /etc/cassandra/pre_run.sh:
     exists: false
 
+  /etc/cassandra/liveness-probe.sh:
+    exists: true
+
   /etc/cassandra/readiness-probe.sh:
     exists: true
 

--- a/docker/bootstrap/files/liveness-probe.sh
+++ b/docker/bootstrap/files/liveness-probe.sh
@@ -1,0 +1,1 @@
+readiness-probe.sh

--- a/pkg/apis/db/v1alpha1/cassandracluster_types.go
+++ b/pkg/apis/db/v1alpha1/cassandracluster_types.go
@@ -35,7 +35,7 @@ const (
 	DefaultReadinessHealthCheckPeriod   int32 = 10
 
 	defaultCassandraImage         = "cassandra:3.11"
-	defaultBootstrapImage         = "orangeopensource/cassandra-bootstrap:0.1.6"
+	defaultBootstrapImage         = "orangeopensource/cassandra-bootstrap:0.1.7"
 	defaultServiceAccountName     = "cassandra-cluster-node"
 	InitContainerCmd              = "cp -vr /etc/cassandra/* /bootstrap"
 	defaultMaxPodUnavailable      = 1

--- a/pkg/controller/cassandracluster/generator.go
+++ b/pkg/controller/cassandracluster/generator.go
@@ -788,7 +788,7 @@ func createCassandraContainer(cc *api.CassandraCluster, status *api.CassandraClu
 					Command: []string{
 						"/bin/bash",
 						"-c",
-						"/etc/cassandra/readiness-probe.sh",
+						"/etc/cassandra/liveness-probe.sh",
 					},
 				},
 			},

--- a/pkg/controller/cassandracluster/testdata/cassandracluster-2DC-dc1-rack1-sts.yaml
+++ b/pkg/controller/cassandracluster/testdata/cassandracluster-2DC-dc1-rack1-sts.yaml
@@ -94,7 +94,7 @@ spec:
               command:
                 - /bin/bash
                 - -c
-                - /etc/cassandra/readiness-probe.sh
+                - /etc/cassandra/liveness-probe.sh
             failureThreshold: 3
             initialDelaySeconds: 120
             periodSeconds: 10


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | []
| New feature?    | [x]
| API breaks?     | []
| Deprecations?   | []
| Related tickets | fixes #277
| License         | Apache 2.0


### What's in this PR?
This PR adds back the ability to use different scripts for the liveness and readiness probes, but it preserves the default behavior (introduced in #234) where the same script is used for both.

The `readiness-probe.sh` script will continue to be used for both the liveness and readiness probes, since `liveness-probe.sh` is a symlink to `readiness-probe.sh`.

However, by using separate filenames for each of the probes, it is now possible to override this behavior, and define separate scripts for each type of probe.



### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [ ] Append changelog

