### PR TITLE
New release 1.0.1

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,9 +1,16 @@
 
 # CassKop Cassandra Kubernetes Operator Changelog
 
-## Unreleased
+## v1.0.1
 
 ### Added
+
+- PR [#280](https://github.com/Orange-OpenSource/casskop/pull/280) - Upgrade Icarus to 1.0.5
+- PR [#279](https://github.com/Orange-OpenSource/casskop/pull/279) - Add option to specify resources at DCs level
+- PR [#278](https://github.com/Orange-OpenSource/casskop/pull/278) - Make separate liveness/readiness probes possible
+- PR [#276](https://github.com/Orange-OpenSource/casskop/pull/276) - Upgrade Icarus and add errors to status
+- PR [#275](https://github.com/Orange-OpenSource/casskop/pull/275) - Use static name for k3d cluster
+- PR [#274](ttps://github.com/Orange-OpenSource/casskop/pull/274) - Fix website doc and add search ability
 
 ### Changed
 

--- a/helm/cassandra-operator/Chart.yaml
+++ b/helm/cassandra-operator/Chart.yaml
@@ -4,19 +4,21 @@ name: cassandra-operator
 home: https://github.com/Orange-OpenSource/casskop
 sources:
   - https://github.com/Orange-OpenSource/casskop
-version: 1.0.0
-appVersion: 1.0.0-release
+version: 1.0.1
+appVersion: 1.0.1-release
 maintainers:
   - name: allamand
     email: sebastien.allamand@orange.com
   - name: cscetbon
-    email: cscetbon.ext@orange.com
+    email: cscetbon@gmail.com
   - name: jal06
     email: jeanarmel.luce@orange.com
   - name: erdrix
     email: aguitton.ext@orange.com
   - name: fdehay
     email: franck.dehay@orange.com
+  - name: PERES-Richard
+    email: richardperes.info@gmail.com
 keywords:
 - operator
 - cassandra

--- a/helm/cassandra-operator/values.yaml
+++ b/helm/cassandra-operator/values.yaml
@@ -2,7 +2,7 @@
 ##
 image:
   repository: orangeopensource/casskop
-  tag: v1.0.0-release
+  tag: v1.0.1-release
   pullPolicy: Always
   imagePullSecrets:
     enabled: false

--- a/multi-casskop/helm/multi-casskop/Chart.yaml
+++ b/multi-casskop/helm/multi-casskop/Chart.yaml
@@ -4,19 +4,21 @@ name: multi-casskop
 home: https://github.com/Orange-OpenSource/casskop/multi-casskop
 sources:
   - https://github.com/Orange-OpenSource/casskop/multi-casskop
-version: 1.0.0
-appVersion: 1.0.0-release
+version: 1.0.1
+appVersion: 1.0.1-release
 maintainers:
   - name: allamand
     email: sebastien.allamand@orange.com
   - name: cscetbon
-    email: cscetbon.ext@orange.com
+    email: cscetbon@gmail.com
   - name: jal06
     email: jeanarmel.luce@orange.com
   - name: erdrix
     email: aguitton.ext@orange.com
   - name: fdehay
     email: franck.dehay@orange.com
+  - name: PERES-Richard
+    email: richardperes.info@gmail.com
 keywords:
 - operator
 - cassandra

--- a/multi-casskop/helm/multi-casskop/values.yaml
+++ b/multi-casskop/helm/multi-casskop/values.yaml
@@ -2,7 +2,7 @@
 ##
 image:
   repository: orangeopensource/multi-casskop
-  tag: v1.0.0-release
+  tag: v1.0.1-release
   pullPolicy: Always
   imagePullSecrets:
     enabled: false

--- a/multi-casskop/samples/gke/terraform/main.tf
+++ b/multi-casskop/samples/gke/terraform/main.tf
@@ -68,7 +68,7 @@ variable "managed_zone" {
 variable "casskop_image_tag" {
   description = ""
   type        = string
-  default     = "v1.0.0-release"
+  default     = "v1.0.1-release"
 }
 
 // Provider definition

--- a/multi-casskop/version/version.go
+++ b/multi-casskop/version/version.go
@@ -15,5 +15,5 @@
 package version
 
 var (
-	Version = "1.0.0"
+	Version = "1.0.1"
 )

--- a/version/version.go
+++ b/version/version.go
@@ -15,5 +15,5 @@
 package version
 
 var (
-	Version = "1.0.0"
+	Version = "1.0.1"
 )


### PR DESCRIPTION
New release that includes:

- PR [#280](https://github.com/Orange-OpenSource/casskop/pull/280) - Upgrade Icarus to 1.0.5
- PR [#279](https://github.com/Orange-OpenSource/casskop/pull/279) - Add option to specify resources at DCs level
- PR [#278](https://github.com/Orange-OpenSource/casskop/pull/278) - Make separate liveness/readiness probes possible
- PR [#276](https://github.com/Orange-OpenSource/casskop/pull/276) - Upgrade Icarus and add errors to status
- PR [#275](https://github.com/Orange-OpenSource/casskop/pull/275) - Use static name for k3d cluster
- PR [#274](ttps://github.com/Orange-OpenSource/casskop/pull/274) - Fix website doc and add search ability