### PR TITLE
Restrict psp role in helm chart to get and list

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,10 +106,10 @@ orbs:
                     false;
                   }
                 fi
-#                if [ << parameters.test_type >> = "kuttl" ]
-#                then
-#                  make kuttl-test-fix-arg << parameters.test_name >>
-#                fi
+                if [ << parameters.test_type >> = "kuttl" ]
+                then
+                  make kuttl-test-fix-arg << parameters.test_name >>
+                fi
   operator:
     # Parameters anchor
     .params_operator: &params_operator

--- a/helm/cassandra-operator/templates/role.yaml
+++ b/helm/cassandra-operator/templates/role.yaml
@@ -104,9 +104,6 @@ metadata:
     release: {{ .Release.Name }}
   name: {{ template "cassandra-operator.name" . }}-cluster-node
 rules:
-  - apiGroups: ['policy']
-    resources: ['podsecuritypolicies']
-    verbs:     ['list','watch']
   - apiGroups: [""]
     resources: ["pods", "configmaps", "secrets" ]
     verbs: ["get", "list", "watch"]

--- a/helm/cassandra-operator/templates/role.yaml
+++ b/helm/cassandra-operator/templates/role.yaml
@@ -106,7 +106,7 @@ metadata:
 rules:
   - apiGroups: ['policy']
     resources: ['podsecuritypolicies']
-    verbs:     ['use']
+    verbs:     ['list','watch']
   - apiGroups: [""]
     resources: ["pods", "configmaps", "secrets" ]
     verbs: ["get", "list", "watch"]


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | []
| New feature?    | []
| API breaks?     | []
| Deprecations?   | []
| License         | Apache 2.0

### What's in this PR?
This Pr restricts the pod security policies that need to be applied from "use" to "list" and "watch"

### Why?
In our internal K8S cluster the "use" policy is not allowed at it enables to use the "priviledged" policy

### Checklist
- [X] Implementation tested
