### PR TITLE
Do not use data folder to store downloaded sstables

### DIFF
--- a/pkg/backrest/backrest.go
+++ b/pkg/backrest/backrest.go
@@ -41,7 +41,7 @@ func (c *Client) PerformRestore(restore *api.CassandraRestore,
 		GlobalRequest: true,
 		Import_: &icarus.AllOfRestoreOperationRequestImport_{
 			Type_: "import",
-			SourceDir: "/var/lib/cassandra/data/downloadedsstables",
+			SourceDir: "/var/lib/cassandra/downloadedsstables",
 		},
 		Entities: restore.Spec.Entities,
 		K8sSecretName: restore.Spec.Secret,

--- a/pkg/cassandrabackup/operations_test.go
+++ b/pkg/cassandrabackup/operations_test.go
@@ -43,7 +43,7 @@ func performRestoreMock(codeStatus int) (*icarus.RestoreOperationResponse, error
 	client := newBuildedMockClient()
 	defer httpmock.DeactivateAndReset()
 
-	sourceDir         := "/var/lib/cassandra/data/downloadedsstables"
+	sourceDir         := "/var/lib/cassandra/downloadedsstables"
 
 	restoreOperationRequest := icarus.RestoreOperationRequest {
 		Type_: "restore",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [X]

There are some issues with the backup when downloadedsstables folders is put in data 