### PR TITLE
Enforce HARDLINKS restore strategy as it is faster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,6 +185,7 @@ docker-generate-k8s:
 		-v $(shell go env GOCACHE):/root/.cache/go-build:delegated --env GO111MODULE=on \
 		--env https_proxy=$(https_proxy) --env http_proxy=$(http_proxy) \
 		$(BUILD_IMAGE):$(OPERATOR_SDK_VERSION) /bin/bash -c 'operator-sdk generate k8s'
+	cp deploy/crds/* helm/*/crds/
 	
 docker-generate-crds:
 	echo "Generate crds"

--- a/deploy/crds/db.orange.com_cassandrarestores_crd.yaml
+++ b/deploy/crds/db.orange.com_cassandrarestores_crd.yaml
@@ -67,13 +67,6 @@ spec:
                 description: When set do not delete truncated SSTables after they've
                   been restored during CLEANUP phase. Defaults to false
                 type: boolean
-              restorationStrategyType:
-                description: Strategy telling how we should go about restoration,
-                  please refer to details in backup and sidecar documentation
-                enum:
-                - HARDLINKS
-                - IMPORT
-                type: string
               schemaVersion:
                 description: Version of the schema to restore from. Upon backup, a
                   schema version is automatically appended to a snapshot name and

--- a/helm/cassandra-operator/crds/db.orange.com_cassandrarestores_crd.yaml
+++ b/helm/cassandra-operator/crds/db.orange.com_cassandrarestores_crd.yaml
@@ -67,13 +67,6 @@ spec:
                 description: When set do not delete truncated SSTables after they've
                   been restored during CLEANUP phase. Defaults to false
                 type: boolean
-              restorationStrategyType:
-                description: Strategy telling how we should go about restoration,
-                  please refer to details in backup and sidecar documentation
-                enum:
-                - HARDLINKS
-                - IMPORT
-                type: string
               schemaVersion:
                 description: Version of the schema to restore from. Upon backup, a
                   schema version is automatically appended to a snapshot name and

--- a/multi-casskop/Makefile
+++ b/multi-casskop/Makefile
@@ -161,8 +161,11 @@ BUILD_CMD = operator-sdk build $(REPOSITORY):$(VERSION) --image-build-args \
 
 docker-generate-k8s:
 	echo "Generate zzz-deepcopy objects"
+	cd ../ && make docker-generate-k8s
+	cp -v ../deploy/crds/* helm/*/crds/
 	$(DOCKER_BUILD) '$(MULTI_CASSKOP); $(GENERATE_CMD)'
 	$(DOCKER_BUILD) '$(MULTI_CASSKOP); $(GENERATE_K8S)'
+	cp -v deploy/crds/* helm/*/crds/
 
 docker-build-operator:
 	echo "Build Cassandra Operator. Using cache from "$(shell go env GOCACHE)

--- a/multi-casskop/go.sum
+++ b/multi-casskop/go.sum
@@ -713,6 +713,8 @@ github.com/influxdata/influxdb v1.7.7/go.mod h1:qZna6X/4elxqT3yI9iZYdZrWWdeFOOpr
 github.com/influxdata/influxdb v1.7.7/go.mod h1:qZna6X/4elxqT3yI9iZYdZrWWdeFOOprn86kgg4+IzY=
 github.com/instaclustr/instaclustr-icarus-go-client v0.0.0-20200806083402-194994f71666 h1:kmcf0wJ6em51iiIQuny7n8xmGmj5zN27a+PhaVLY9z0=
 github.com/instaclustr/instaclustr-icarus-go-client v0.0.0-20200806083402-194994f71666/go.mod h1:HvvSNvbFZ2UwNhbwZUP3RG+UHcFCAy/lFahKX1xKfFc=
+github.com/instaclustr/instaclustr-icarus-go-client v0.0.0-20201103172213-3e9c434b280c h1:4jJ028DTFj1UOXAjn8tSffmyLabdY/QSTlGOahZrRMI=
+github.com/instaclustr/instaclustr-icarus-go-client v0.0.0-20201103172213-3e9c434b280c/go.mod h1:2+9I3yZFu2UU6G+fRrnJqUH9tl1iq2W3dCUkjzQTMBM=
 github.com/jackc/fake v0.0.0-20150926172116-812a484cc733/go.mod h1:WrMFNQdiFJ80sQsxDoMokWK1W5TQtxBFNpzWTD84ibQ=
 github.com/jackc/pgx v3.2.0+incompatible/go.mod h1:0ZGrqGqkRlliWnWB4zKnWtjbSWbGkVEFm4TeybAXq+I=
 github.com/jarcoal/httpmock v1.0.4/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=

--- a/multi-casskop/helm/multi-casskop/crds/db.orange.com_cassandrarestores_crd.yaml
+++ b/multi-casskop/helm/multi-casskop/crds/db.orange.com_cassandrarestores_crd.yaml
@@ -67,13 +67,6 @@ spec:
                 description: When set do not delete truncated SSTables after they've
                   been restored during CLEANUP phase. Defaults to false
                 type: boolean
-              restorationStrategyType:
-                description: Strategy telling how we should go about restoration,
-                  please refer to details in backup and sidecar documentation
-                enum:
-                - HARDLINKS
-                - IMPORT
-                type: string
               schemaVersion:
                 description: Version of the schema to restore from. Upon backup, a
                   schema version is automatically appended to a snapshot name and

--- a/multi-casskop/helm/multi-casskop/crds/multicluster_v1alpha1_cassandramulticluster_cr.yaml
+++ b/multi-casskop/helm/multi-casskop/crds/multicluster_v1alpha1_cassandramulticluster_cr.yaml
@@ -1,0 +1,51 @@
+apiVersion: db.orange.com/v1alpha1
+kind: MultiCasskop
+metadata:
+  name: MultiCasskop-demo
+spec:
+  # Add fields here
+  base:
+    apiVersion: "db.orange.com/v1alpha1"
+    kind: "CassandraCluster"
+    metadata:
+      name: cassandra-demo
+      namespace: cassandra-demo
+      labels:
+        cluster: casskop
+    spec:
+      resources:         
+        requests:
+          cpu: '0.3'
+          memory: 2Gi
+        limits:
+          cpu: '0.3'
+          memory: 2Gi
+  override:
+    gke_dfy-bac-a-sable_europe-west1-b_istio1:
+      metadata:
+        name: cassandra-demo1
+        namespace: cassandra-demo
+      spec:
+        topology:
+          dc:
+            - name: dc1
+              nodesPerRacks: 1
+              numTokens: 256
+              rack:
+                - name: rack1
+                - name: rack2
+    gke_dfy-bac-a-sable_us-central1-a_istio2:
+      metadata:
+        name: cassandra-demo2
+        namespace: cassandra-demo
+      spec:
+        topology:
+          dc:
+            - name: dc2
+              nodesPerRacks: 1
+              numTokens: 256
+              rack:
+                - name: rack3
+                - name: rack4
+      
+  

--- a/pkg/apis/db/v1alpha1/cassandrarestore_types.go
+++ b/pkg/apis/db/v1alpha1/cassandrarestore_types.go
@@ -69,9 +69,6 @@ type CassandraRestoreSpec struct {
 	// want to restore a table for which its CQL schema has not changed but it has changed for other table / keyspace
 	// but a schema for that node has changed by doing that. Defaults to False
 	ExactSchemaVersion 		bool `json:"exactSchemaVersion,omitempty""`
-	// Strategy telling how we should go about restoration, please refer to details in backup and sidecar documentation
-	// +kubebuilder:validation:Enum={"HARDLINKS","IMPORT"}
-	RestorationStrategyType string `json:"restorationStrategyType,omitempty"`
 	// Database entities to restore, it might be either only keyspaces or only tables prefixed by their respective
 	// keyspace, e.g. 'k1,k2' if one wants to backup whole keyspaces or 'ks1.t1,ks2.t2' if one wants to restore specific
 	// tables. These formats are mutually exclusive so 'k1,k2.t2' is invalid. An empty field will restore all keyspaces

--- a/pkg/backrest/backrest.go
+++ b/pkg/backrest/backrest.go
@@ -47,7 +47,7 @@ func (c *Client) PerformRestore(restore *api.CassandraRestore,
 		K8sSecretName: restore.Spec.Secret,
 		CassandraDirectory: restore.Spec.CassandraDirectory,
 		SchemaVersion: restore.Spec.SchemaVersion,
-		RestorationStrategyType: restore.Spec.RestorationStrategyType,
+		RestorationStrategyType: "HARDLINKS",
 		ResolveHostIdFromTopology: true,
 	}
 

--- a/pkg/backrest/backrest_test.go
+++ b/pkg/backrest/backrest_test.go
@@ -24,7 +24,6 @@ func TestPerformRestore(t *testing.T) {
 		Spec:       v1alpha1.CassandraRestoreSpec{
 			ConcurrentConnection:    &concurrentConnection,
 			NoDeleteTruncates:       true,
-			RestorationStrategyType: "HARDLINKS",
 			CassandraCluster:        "cassandra-bgl",
 			CassandraBackup:         "gcp_backup",
 		},

--- a/samples/db.orange.com_v1alpha1_cassandrarestore.yaml
+++ b/samples/db.orange.com_v1alpha1_cassandrarestore.yaml
@@ -26,9 +26,6 @@ spec:
   #	There might be cases when we want to restore a table for which its CQL schema has not changed
   #	but it has changed for other table / keyspace but a schema for that node has changed by doing that.
 #   exactSchemaVersion:
-  # strategy telling how we should go about restoration, please refer to details in backup and sidecar documentation
-  # Enum={"HARDLINKS","IMPORT"}
-  restorationStrategyType: HARDLINKS
   # name of Kubernetes secret from which credentials used for the communication to cloud storage providers are read,
   #	if not specified, secret name to be read will be automatically derived in form 'cassandra-backup-restore-secret-cluster-{name-of-cluster}'.
   #	These secrets are used only in case protocol in storageLocation is gcp, azure or s3.

--- a/website/docs/5_operations/3_5_backup_restore.md
+++ b/website/docs/5_operations/3_5_backup_restore.md
@@ -73,7 +73,6 @@ metadata:
 spec:
   cassandraBackup: nightly-cassandra-backup
   cassandraCluster: test-cluster
-  restorationStrategyType: HARDLINKS
   entities: k1.t1
 ```
 

--- a/website/docs/6_references/6_cassandra_restore.md
+++ b/website/docs/6_references/6_cassandra_restore.md
@@ -14,7 +14,6 @@ metadata:
 spec:
   cassandraCluster: cluster-demo
   cassandraBackup: backup-demo
-  restorationStrategyType: HARDLINKS
   entities: k1.standard1
 ```
 
@@ -37,7 +36,6 @@ spec:
 |entities|string|Database entities to restore, it might be either only keyspaces or only tables prefixed by their respective keyspace, e.g. 'k1,k2' if one wants to backup whole keyspaces or 'ks1.t1,ks2.t2' if one wants to restore specific tables. These formats are mutually exclusive so 'k1,k2.t2' is invalid. An empty field will restore all keyspaces|No|-|
 |exactSchemaVersion|boolean|When set a running node's schema version must match the snapshot's schema version. There might be cases when we want to restore a table for which its CQL schema has not changed but it has changed for other table / keyspace but a schema for that node has changed by doing that. Defaults to False|No|false|
 |noDeleteTruncates|boolean|When set do not delete truncated SSTables after they've been restored during CLEANUP phase. Defaults to false|No|false|
-|restorationStrategyType|string|Strategy telling how we should go about restoration, please refer to details in backup and sidecar documentation. Enum values are : HARDLINKS or IMPORT|No|-|
 |schemaVersion|string|Version of the schema to restore from. Upon backup, a schema version is automatically appended to a snapshot name and its manifest is uploaded under that name. In case we have two snapshots having same name, we might distinguish between the two of them by using the schema version. If schema version is not specified, we expect a unique backup taken with respective snapshot name. This schema version has to match the version of a Cassandra node we are doing restore for (hence, by proxy, when global request mode is used, all nodes have to be on exact same schema version). Defaults to False|No|-|
 |secret|string|Name of Secret to use when accessing cloud storage providers|No|-|
 


### PR DESCRIPTION
IMPORT restore strategy implies reading sstables and rewriting them which is longer that using hardlinks. That PR enforces that choice.