### PR TITLE
Add check if cassandraBackup.Annotations map is nil before assignement

### DIFF
--- a/pkg/controller/cassandrabackup/reconcile.go
+++ b/pkg/controller/cassandrabackup/reconcile.go
@@ -106,7 +106,7 @@ func (r *ReconcileCassandraBackup) Reconcile(request reconcile.Request) (reconci
 		instanceChanged = false
 	} else {
 		if cassandraBackup.Annotations == nil {
-			cassandraBackup.Annotations = make(map[string] string )
+			cassandraBackup.Annotations = make(map[string] string)
 		}
 		cassandraBackup.Annotations[annotationLastApplied] = lac
 		defer r.client.Update(context.TODO(), cassandraBackup)

--- a/pkg/controller/cassandrabackup/reconcile.go
+++ b/pkg/controller/cassandrabackup/reconcile.go
@@ -105,6 +105,9 @@ func (r *ReconcileCassandraBackup) Reconcile(request reconcile.Request) (reconci
 	if lac, _ := cassandraBackup.ComputeLastAppliedAnnotation(); lac == cassandraBackup.Annotations[annotationLastApplied] {
 		instanceChanged = false
 	} else {
+		if cassandraBackup.Annotations == nil {
+			cassandraBackup.Annotations = make(map[string] string )
+		}
 		cassandraBackup.Annotations[annotationLastApplied] = lac
 		defer r.client.Update(context.TODO(), cassandraBackup)
 	}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| License         | Apache 2.0


### What's in this PR?
Add a map is nil check before setting last applied action on CassandraBackup.


### Why?
To avoid error when there's no annotation(s) (and so the map is nil).


### Checklist

- [ ] Append changelog