### PR TITLE
Upgrade to 1.0.8

### DIFF
--- a/pkg/apis/db/v1alpha1/cassandracluster_types.go
+++ b/pkg/apis/db/v1alpha1/cassandracluster_types.go
@@ -36,7 +36,7 @@ const (
 
 	defaultCassandraImage     = "cassandra:3.11"
 	defaultBootstrapImage     = "orangeopensource/cassandra-bootstrap:0.1.7"
-	DefaultBackRestImage      = "gcr.io/cassandra-operator/instaclustr-icarus:1.0.7"
+	DefaultBackRestImage      = "gcr.io/cassandra-operator/instaclustr-icarus:1.0.8"
 	defaultServiceAccountName = "cassandra-cluster-node"
 	InitContainerCmd          = "cp -vr /etc/cassandra/* /bootstrap"
 	defaultMaxPodUnavailable  = 1


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [X]

Bubble error when an error is met. I was able to confirm that if I'm using the wrong format for the table to be renamed I see the error being caught and stored in the CassandraRestore object
```
"condition": {
    "failureCause": [
      {
        "message": "Failed tables to refresh: {k1.standard2=Unknown column c1 during deserialization}",
        "source": "cassandra-e2e-dc1-rack1-0"
      },
      {
        "message": "Failed tables to refresh: {k1.standard2=Unknown column c1 during deserialization}",
        "source": "cassandra-e2e-dc1-rack1-1"
      }
    ],
    "lastTransitionTime": "Thu, 4 Feb 2021 03:55:26 GMT",
    "type": "FAILED"
  }
```