### PR TITLE
Bump release and icarus to support restore to a different keyspace

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,12 @@
 
 # CassKop Cassandra Kubernetes Operator Changelog
 
+## v1.1.3
+
+- PR [#302](https://github.com/Orange-OpenSource/casskop/pull/302) - Fix Bootstrap issue
+- PR [#303](https://github.com/Orange-OpenSource/casskop/pull/303) - Upgrade Icarus to 1.0.9
+
+
 ## v1.1.2
 
 - PR [#298](https://github.com/Orange-OpenSource/casskop/pull/297) - Fix Helm publishing

--- a/helm/cassandra-operator/Chart.yaml
+++ b/helm/cassandra-operator/Chart.yaml
@@ -4,8 +4,8 @@ name: cassandra-operator
 home: https://github.com/Orange-OpenSource/casskop
 sources:
   - https://github.com/Orange-OpenSource/casskop
-version: 1.1.2
-appVersion: 1.1.2-release
+version: 1.1.3
+appVersion: 1.1.3-release
 maintainers:
   - name: allamand
     email: sebastien.allamand@orange.com

--- a/helm/cassandra-operator/values.yaml
+++ b/helm/cassandra-operator/values.yaml
@@ -2,7 +2,7 @@
 ##
 image:
   repository: orangeopensource/casskop
-  tag: v1.1.2-release
+  tag: v1.1.3-release
   pullPolicy: Always
   imagePullSecrets:
     enabled: false

--- a/multi-casskop/helm/multi-casskop/Chart.yaml
+++ b/multi-casskop/helm/multi-casskop/Chart.yaml
@@ -4,8 +4,8 @@ name: multi-casskop
 home: https://github.com/Orange-OpenSource/casskop/multi-casskop
 sources:
   - https://github.com/Orange-OpenSource/casskop/multi-casskop
-version: 1.1.2
-appVersion: 1.1.2-release
+version: 1.1.3
+appVersion: 1.1.3-release
 maintainers:
   - name: allamand
     email: sebastien.allamand@orange.com

--- a/multi-casskop/helm/multi-casskop/values.yaml
+++ b/multi-casskop/helm/multi-casskop/values.yaml
@@ -2,7 +2,7 @@
 ##
 image:
   repository: orangeopensource/multi-casskop
-  tag: v1.1.2-release
+  tag: v1.1.3-release
   pullPolicy: Always
   imagePullSecrets:
     enabled: false

--- a/multi-casskop/samples/gke/terraform/main.tf
+++ b/multi-casskop/samples/gke/terraform/main.tf
@@ -68,7 +68,7 @@ variable "managed_zone" {
 variable "casskop_image_tag" {
   description = ""
   type        = string
-  default     = "v1.1.2-release"
+  default     = "v1.1.3-release"
 }
 
 // Provider definition

--- a/multi-casskop/version/version.go
+++ b/multi-casskop/version/version.go
@@ -15,5 +15,5 @@
 package version
 
 var (
-	Version = "1.1.2"
+	Version = "1.1.3"
 )

--- a/pkg/apis/db/v1alpha1/cassandracluster_types.go
+++ b/pkg/apis/db/v1alpha1/cassandracluster_types.go
@@ -36,7 +36,7 @@ const (
 
 	defaultCassandraImage     = "cassandra:3.11"
 	defaultBootstrapImage     = "orangeopensource/cassandra-bootstrap:0.1.8"
-	DefaultBackRestImage      = "gcr.io/cassandra-operator/instaclustr-icarus:1.0.8"
+	DefaultBackRestImage      = "gcr.io/cassandra-operator/instaclustr-icarus:1.0.9"
 	defaultServiceAccountName = "cassandra-cluster-node"
 	InitContainerCmd          = "cp -vr /etc/cassandra/* /bootstrap"
 	defaultMaxPodUnavailable  = 1

--- a/version/version.go
+++ b/version/version.go
@@ -15,5 +15,5 @@
 package version
 
 var (
-	Version = "1.1.2"
+	Version = "1.1.3"
 )


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| New feature?    | [X]
| License         | Apache 2.0


### What's in this PR?

New release that mainly integrates the ability to restore the backup of a table **A** belonging to a keyspace **k1** into a table **B** belonging to a keyspace **k2**. table **k1.A** must be in the backup used to restore and table **k2.B** must be created and have the same structure as table **k1.A**.

