### PR TITLE
Custom script when Cassandra starts up

### DIFF
--- a/tools/publish_helm_gcs.sh
+++ b/tools/publish_helm_gcs.sh
@@ -50,7 +50,6 @@ setup_helm_client() {
 
     PATH="$(pwd)/tmp/linux-amd64/:$PATH"
 
-    helm init --client-only
     helm repo add incubator-orange "$INCUBATOR_REPO_URL"
 }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| New feature?    | [X]
| License         | Apache 2.0


### What's in this PR?
 This PR has the extended functionality of running a custom script when the Cassandra pod is started up, using the postStart lifecycle hook. One use case is when the user wishes to create custom roles on the startup of Cassandra
### Why?
In case a user wishes to perform an operation immediately after Cassandra is started up, such as create a role with cqlsh, the script specified by /etc/cassandra_post_start.sh can be injected via configmap to run on post-start.

