### PR TITLE
Added `fsGroup` to `CassandraCluster.Spec`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,10 @@
 
 # CassKop Cassandra Kubernetes Operator Changelog
 
+## v1.1.4
+
+- PR [#314](https://github.com/Orange-OpenSource/casskop/pull/314) - Added `fsGroup` to `CassandraCluster.Spec`
+
 ## v1.1.3
 
 - PR [#302](https://github.com/Orange-OpenSource/casskop/pull/302) - Fix Bootstrap issue

--- a/deploy/crds/db.orange.com_cassandraclusters_crd.yaml
+++ b/deploy/crds/db.orange.com_cassandraclusters_crd.yaml
@@ -111,6 +111,12 @@ spec:
                 description: DeletePVC defines if the PVC must be deleted when the
                   cluster is deleted it is false by default
                 type: boolean
+              fsGroup:
+                description: FSGroup defines the GID owning volumes in the Cassandra
+                  image
+                format: int64
+                minimum: 1
+                type: integer
               gcStdout:
                 description: 'GCStdout set the parameter CASSANDRA_GC_STDOUT which
                   configure the JVM -Xloggc: true by default'

--- a/documentation/uml/crd.puml
+++ b/documentation/uml/crd.puml
@@ -21,6 +21,7 @@ CassandraClusterSpec : nodesPerRacks
 CassandraClusterSpec : baseImage
 CassandraClusterSpec : version
 CassandraClusterSpec : runAsUser
+CassandraClusterSpec : fsGroup
 CassandraClusterSpec : readOnlyRootFileSystem
 CassandraClusterSpec : initContainerImage
 CassandraClusterSpec : initContainerCmd

--- a/helm/cassandra-operator/crds/db.orange.com_cassandraclusters_crd.yaml
+++ b/helm/cassandra-operator/crds/db.orange.com_cassandraclusters_crd.yaml
@@ -304,6 +304,11 @@ spec:
                 format: int64
                 minimum: 1
                 type: integer
+              fsGroup:
+                description: FSGroup defines the GID owning volumes in the Cassandra image
+                format: int64
+                minimum: 1
+                type: integer
               service:
                 description: ServicePolicy defines the policy for headless service
                   owned by CassKop operator.

--- a/multi-casskop/helm/multi-casskop/crds/db.orange.com_cassandraclusters_crd.yaml
+++ b/multi-casskop/helm/multi-casskop/crds/db.orange.com_cassandraclusters_crd.yaml
@@ -304,6 +304,11 @@ spec:
                 format: int64
                 minimum: 1
                 type: integer
+              fsGroup:
+                description: FSGroup defines the GID owning volumes in the Cassandra image
+                format: int64
+                minimum: 1
+                type: integer
               service:
                 description: ServicePolicy defines the policy for headless service
                   owned by CassKop operator.

--- a/pkg/apis/db/v1alpha1/cassandracluster_types.go
+++ b/pkg/apis/db/v1alpha1/cassandracluster_types.go
@@ -58,6 +58,8 @@ const (
 
 	//DefaultUserID is the default ID to use in cassandra image (RunAsUser)
 	DefaultUserID int64 = 999
+	//DefaultFSGroup is the default GID owning volumes in the Cassandra image
+	DefaultFSGroup int64 = 1
 )
 
 // ClusterStateInfo describe a cluster state
@@ -142,6 +144,9 @@ func (cc *CassandraCluster) CheckDefaults() {
 
 	if ccs.RunAsUser == nil {
 		ccs.RunAsUser = func(i int64) *int64 { return &i }(DefaultUserID)
+	}
+	if ccs.FSGroup == nil {
+		ccs.FSGroup = func(i int64) *int64 { return &i }(DefaultFSGroup)
 	}
 	if ccs.ReadOnlyRootFilesystem == nil {
 		ccs.ReadOnlyRootFilesystem = func(b bool) *bool { return &b }(true)
@@ -754,6 +759,10 @@ type CassandraClusterSpec struct {
 	// RunAsUser define the id of the user to run in the Cassandra image
 	// +kubebuilder:validation:Minimum=1
 	RunAsUser *int64 `json:"runAsUser,omitempty"`
+
+	// FSGroup defines the GID owning volumes in the Cassandra image
+	// +kubebuilder:validation:Minimum=1
+	FSGroup *int64 `json:"fsGroup,omitempty"`
 
 	// Make the pod as Readonly
 	ReadOnlyRootFilesystem *bool `json:"readOnlyRootFilesystem,omitempty"`

--- a/pkg/apis/db/v1alpha1/cassandracluster_types_test.go
+++ b/pkg/apis/db/v1alpha1/cassandracluster_types_test.go
@@ -16,13 +16,14 @@ package v1alpha1
 
 import (
 	"io/ioutil"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"log"
 	"path/filepath"
 	"sort"
 	"strings"
 	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/ghodss/yaml"
 	"github.com/stretchr/testify/assert"
@@ -502,6 +503,7 @@ func TestSetDefaults(t *testing.T) {
 	assert.Equal(resource.MustParse("1Gi"), *cluster.Spec.Resources.Limits.Memory())
 
 	assert.Equal(DefaultUserID, *cluster.Spec.RunAsUser)
+	assert.Equal(DefaultFSGroup, *cluster.Spec.FSGroup)
 	assert.Equal(ClusterPhaseInitial.Name, cluster.Status.Phase)
 	assert.Equal(int32(defaultMaxPodUnavailable), cluster.Spec.MaxPodUnavailable)
 	assert.Equal([]string{"defaults-test-dc1-rack1-0.defaults-test.default"}, cluster.Status.SeedList)

--- a/pkg/apis/db/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/db/v1alpha1/zz_generated.deepcopy.go
@@ -218,6 +218,11 @@ func (in *CassandraClusterSpec) DeepCopyInto(out *CassandraClusterSpec) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.FSGroup != nil {
+		in, out := &in.FSGroup, &out.FSGroup
+		*out = new(int64)
+		**out = **in
+	}
 	if in.ReadOnlyRootFilesystem != nil {
 		in, out := &in.ReadOnlyRootFilesystem, &out.ReadOnlyRootFilesystem
 		*out = new(bool)

--- a/pkg/controller/cassandracluster/generator.go
+++ b/pkg/controller/cassandracluster/generator.go
@@ -348,7 +348,7 @@ func generateCassandraStatefulSet(cc *api.CassandraCluster, status *api.Cassandr
 					SecurityContext: &v1.PodSecurityContext{
 						RunAsUser:    cc.Spec.RunAsUser,
 						RunAsNonRoot: func(b bool) *bool { return &b }(true),
-						FSGroup:      func(i int64) *int64 { return &i }(1),
+						FSGroup:      cc.Spec.FSGroup,
 					},
 
 					InitContainers: []v1.Container{

--- a/website/docs/5_operations/1_cluster_operations.md
+++ b/website/docs/5_operations/1_cluster_operations.md
@@ -23,6 +23,7 @@ Some Updates in the `CassandraCluster` CRD object will trigger a rolling update 
 - `spec.configMap`
 - `spec.gcStdout`
 - `spec.runAsUser`
+- `spec.fsGroup`
 
 Some Updates in the `CassandraCluster` CRD object will not trigger change on the cluster but only in future behavior of
 CassKop :

--- a/website/docs/6_references/1_cassandra_cluster.md
+++ b/website/docs/6_references/1_cassandra_cluster.md
@@ -64,6 +64,7 @@ spec:
 |initContainerImage|string|Image used in the initContainer (use the form : base:version)|Yes|cassandra:latest|
 |initContainerCmd|string|Command to execute in the initContainer in the targeted image|Yes|cp -vr /etc/cassandra/* /bootstrap|
 |runAsUser|int64|Define the id of the user to run in the Cassandra image|Yes|999|
+|fsGroup|int64|FSGroup defines the GID owning volumes in the Cassandra image|No|1|
 |readOnlyRootFilesystem|Make the pod as Readonly|bool|Yes|true|
 |resources|[Resources](#https://godoc.org/k8s.io/api/core/v1#ResourceRequirements)|Define the Requests & Limits resources spec of the "cassandra" container|Yes|-|
 |hardAntiAffinity|bool|HardAntiAffinity defines if the PodAntiAffinity of the statefulset has to be hard (it's soft by default)|Yes|false|


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| Related tickets | fixes #309
| License         | Apache 2.0

### What's in this PR?
This allows to deploy cassandra clusters in K8s environments that restrict the range of allowed fsGroups by excluding fsGroup 1 (current default).

### Checklist

- [x] User guide and development docs updated (if needed)
- [x] Append changelog
