### PR TITLE
Calculate MaxHeapSize from DC Resource or global

### DIFF
--- a/pkg/apis/db/v1alpha1/cassandracluster_types.go
+++ b/pkg/apis/db/v1alpha1/cassandracluster_types.go
@@ -642,6 +642,27 @@ func (cc *CassandraCluster) NumTokensPerRacks(dcRackName string) int32 {
 	return defaultNumTokens
 }
 
+func (cc *CassandraCluster) ResourceOfRack(dcRackName string) v1.ResourceRequirements {
+	dcName := cc.GetDCNameFromDCRackName(dcRackName)
+	dcsize := cc.GetDCSize()
+	defaultResources := cc.Spec.Resources
+
+	if dcsize < 1 {
+		return defaultResources
+	}
+
+	for dc := 0; dc < dcsize; dc++ {
+		if dcName == cc.GetDCName(dc) {
+			storeDC := cc.Spec.Topology.DC[dc]
+			if storeDC.Resources.Limits.Memory().IsZero() {
+				return defaultResources
+			}
+			return storeDC.Resources
+		}
+	}
+	return defaultResources
+}
+
 // GetRollingPartitionPerRacks return rollingPartition defined in spec.topology.dc[].rack[].rollingPartition
 func (cc *CassandraCluster) GetRollingPartitionPerRacks(dcRackName string) int32 {
 	dcsize := cc.GetDCSize()

--- a/pkg/apis/db/v1alpha1/cassandracluster_types.go
+++ b/pkg/apis/db/v1alpha1/cassandracluster_types.go
@@ -642,7 +642,7 @@ func (cc *CassandraCluster) NumTokensPerRacks(dcRackName string) int32 {
 	return defaultNumTokens
 }
 
-func (cc *CassandraCluster) ResourceOfRack(dcRackName string) v1.ResourceRequirements {
+func (cc *CassandraCluster) ResourcesOfRack(dcRackName string) v1.ResourceRequirements {
 	dcName := cc.GetDCNameFromDCRackName(dcRackName)
 	dcsize := cc.GetDCSize()
 	defaultResources := cc.Spec.Resources

--- a/pkg/controller/cassandracluster/generator.go
+++ b/pkg/controller/cassandracluster/generator.go
@@ -411,7 +411,7 @@ func generateResourceQuantity(qs string) resource.Quantity {
 }
 
 func defineJvmMemory(cc *api.CassandraCluster, dcRackName string) JvmMemory {
-	resources := cc.ResourceOfRack(dcRackName)
+	resources := cc.ResourcesOfRack(dcRackName)
 	jvmMemory := JvmMemory{
 		maxHeapSize: defaultJvmMaxHeap,
 	}

--- a/pkg/controller/cassandracluster/testdata/cassandracluster-2DC.yaml
+++ b/pkg/controller/cassandracluster/testdata/cassandracluster-2DC.yaml
@@ -97,7 +97,7 @@ spec:
       memory: 2Gi
     limits:
       cpu: '1'
-      memory: 2Gi
+      memory: 4Gi
   topology:
     dc:
       - name: dc1
@@ -107,7 +107,7 @@ spec:
             memory: 3Gi
           limits:
             cpu: '3'
-            memory: 3Gi
+            memory: 12Gi
         dataCapacity: 10Gi
         dataStorageClass: test-storage
         labels:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [X]
| License         | Apache 2.0


### What's in this PR?
It fixes an issue **in v1** where the max heap size was calculated using _Spec.Resource.Limits_ even if _Resource.Limits_ was configured in the corresponding DC.
