### PR TITLE
Revert "Fix #316 by labeling the cluster uid to each PVC (#322)"

### DIFF
--- a/pkg/controller/cassandracluster/cassandra_status_test.go
+++ b/pkg/controller/cassandracluster/cassandra_status_test.go
@@ -42,7 +42,6 @@ import (
 
 var clusterName = "cassandra-demo"
 var namespace   = "ns"
-var clusterUID = "cassandra-demo-uid"
 
 var cc2Dcs = `
 apiVersion: "db.orange.com/v1alpha1"
@@ -95,8 +94,6 @@ func HelperInitCluster(t *testing.T, name string) (*ReconcileCassandraCluster,
 	*api.CassandraCluster) {
 	var cc api.CassandraCluster
 	yaml.Unmarshal(common.HelperLoadBytes(t, name), &cc)
-
-	cc.ObjectMeta.UID = types.UID(clusterUID) // Set default UID for cc
 
 	ccList := api.CassandraClusterList{
 		TypeMeta: metav1.TypeMeta{
@@ -223,7 +220,6 @@ func helperCreateCassandraCluster(t *testing.T, cassandraClusterFileName string)
 						"cassandraclusters.db.orange.com.rack": rack.Name,
 						"app":                                  "cassandracluster",
 						"cassandracluster":                     cc.Name,
-						"cassandracluster-uid":                 string(cc.GetUID()),
 					},
 				},
 				Status: v1.PodStatus{

--- a/pkg/controller/cassandracluster/generator_test.go
+++ b/pkg/controller/cassandracluster/generator_test.go
@@ -348,7 +348,6 @@ func TestGenerateCassandraStatefulSet(t *testing.T) {
 	assert.Equal(map[string]string{
 		"app":                                  "cassandracluster",
 		"cassandracluster":                     "cassandra-demo",
-		"cassandracluster-uid":                 clusterUID,
 		"cassandraclusters.db.orange.com.dc":   "dc1",
 		"cassandraclusters.db.orange.com.rack": "rack1",
 		"dc-rack":                              "dc1-rack1",

--- a/pkg/controller/cassandracluster/reconcile_test.go
+++ b/pkg/controller/cassandracluster/reconcile_test.go
@@ -525,7 +525,6 @@ func TestCheckNonAllowedChangesScaleDown(t *testing.T) {
 			Labels: map[string]string{
 				"app":                                  "cassandracluster",
 				"cassandracluster":                     "cassandra-demo",
-				"cassandracluster-uid":                 clusterUID,
 				"cassandraclusters.db.orange.com.dc":   "dc2",
 				"cassandraclusters.db.orange.com.rack": "rack1",
 				"cluster":                              "k8s.pic",

--- a/pkg/k8s/util.go
+++ b/pkg/k8s/util.go
@@ -41,7 +41,6 @@ func LabelsForCassandraDCRack(cc *api.CassandraCluster, dcName string, rackName 
 	m := map[string]string{
 		"app":                                  "cassandracluster",
 		"cassandracluster":                     cc.GetName(),
-		"cassandracluster-uid":                 string(cc.GetUID()),
 		"dc-rack":                              cc.GetDCRackName(dcName, rackName),
 		"cassandraclusters.db.orange.com.dc":   dcName,
 		"cassandraclusters.db.orange.com.rack": rackName,


### PR DESCRIPTION
This reverts commit 2b265f0a06c83abb1a7a1c86deeaedb1d50251e0.

| Q               | A
| --------------- | ---
| Bug fix?        | [X]
| License         | Apache 2.0


### What's in this PR?
This PR rollbacks a change that prevents upgrading from a cluster that is not using that new label