### PR TITLE
Added a possibility to configure readinessProbe timeouts for operator deployment

### DIFF
--- a/helm/cassandra-operator/templates/deployment.yaml
+++ b/helm/cassandra-operator/templates/deployment.yaml
@@ -43,9 +43,9 @@ spec:
           exec:
             command:
               - /health
-          initialDelaySeconds: 4
-          periodSeconds: 10
-          failureThreshold: 1
+          initialDelaySeconds: {{ .Values.readinessProbe.timeouts.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.timeouts.periodSeconds }}
+          failureThreshold: {{ .Values.readinessProbe.timeouts.failureThreshold }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         env:

--- a/helm/cassandra-operator/values.yaml
+++ b/helm/cassandra-operator/values.yaml
@@ -18,6 +18,12 @@ resources:
     cpu: 1
     memory: 512Mi
 
+readinessProbe:
+  timeouts:
+    initialDelaySeconds: 4
+    periodSeconds: 10
+    failureThreshold: 1
+
 ## If true, create & deploy the CRD
 ##
 createCustomResource: true

--- a/website/docs/3_configuration_deployment/1_customizable_install_with_helm.md
+++ b/website/docs/3_configuration_deployment/1_customizable_install_with_helm.md
@@ -26,6 +26,9 @@ The following tables lists the configurable parameters of the Cassandra Operator
 | `image.imagePullSecrets.name`    | Name of the secret to connect to docker registry | -                                         |
 | `rbacEnable`                     | If true, create & use RBAC resources             | `true`                                    |
 | `resources`                      | Pod resource requests & limits                   | `{}`                                      |
+| `readinessProbe.timeouts.initialDelaySeconds` | Specifies timeout before first probe attempt | `4`				  |
+| `readinessProbe.timeouts.periodSeconds` | Specifies probe interval                  | `10`                                      |
+| `readinessProbe.timeouts.failureThreshold` | When a probe fails, after time specified in this field Pod will be marked as `Undready`  | `1`                              |
 | `metricService`                  | deploy service for metrics                       | `false`                                   |
 | `debug.enabled`                  | activate DEBUG log level  and enable shareProcessNamespace (allowing ephemeral container usage)                         | `false`                                   |
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | []
| New feature?    | [YES]
| API breaks?     | []
| Deprecations?   | []
| Related tickets | fixes #360 
| License         | Apache 2.0


### What's in this PR?
Added a possibility to configure readinessProbe timeouts for operator deployment via `values.yaml` file.


### Why?
We encountered on a problem that after upgrade of operator its deployment object cannot be marked as "ready".
There is a workaround: we have to increase "failureThreshold" timeout to value higher than 1s and everything works correctly


### Checklist
- [X] Implementation tested

