### PR TITLE
Release 2.0.2

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,21 @@
 
 # CassKop Cassandra Kubernetes Operator Changelog
 
+## v2.0.2
+
+- PR [363](https://github.com/Orange-OpenSource/casskop/pull/363) - Bump CRDs version from v1aplha1 to v2
+- PR [362](https://github.com/Orange-OpenSource/casskop/pull/362) - Added a possibility to configure readinessProbe timeouts for operator deployment
+- PR [361](https://github.com/Orange-OpenSource/casskop/pull/361) - Update Documentation
+- PR [359](https://github.com/Orange-OpenSource/casskop/pull/359) - Do not mount multiple times the same path
+- PR [358](https://github.com/Orange-OpenSource/casskop/pull/358) - Limit ConfigBuilder resources and add ability to specify its image
+- PR [356](https://github.com/Orange-OpenSource/casskop/pull/356) - Bump tar from 6.1.4 to 6.1.11 in /website
+- PR [354](https://github.com/Orange-OpenSource/casskop/pull/354) - Bump url-parse from 1.5.1 to 1.5.3 in /website 
+- PR [353](https://github.com/Orange-OpenSource/casskop/pull/353) - Upgrade to Go 1.17
+- PR [352](https://github.com/Orange-OpenSource/casskop/pull/352) - Bump path-parse from 1.0.6 to 1.0.7 in /website 
+- PR [350](https://github.com/Orange-OpenSource/casskop/pull/350) - Remove pre_stop.sh and update build image
+- PR [349](https://github.com/Orange-OpenSource/casskop/pull/349) - Bump tar from 6.0.5 to 6.1.4 in /website 
+
+
 ## v2.0.1
 
 - PR [#344](https://github.com/Orange-OpenSource/casskop/pull/344) - Revert "Fix #316 by labeling the cluster uid to each PVC (#322)"

--- a/helm/cassandra-operator/Chart.yaml
+++ b/helm/cassandra-operator/Chart.yaml
@@ -4,8 +4,8 @@ name: cassandra-operator
 home: https://github.com/Orange-OpenSource/casskop
 sources:
   - https://github.com/Orange-OpenSource/casskop
-version: 2.0.1
-appVersion: 2.0.1-release
+version: 2.0.2
+appVersion: 2.0.2-release
 maintainers:
   - name: allamand
     email: sebastien.allamand@orange.com

--- a/helm/cassandra-operator/values.yaml
+++ b/helm/cassandra-operator/values.yaml
@@ -2,7 +2,7 @@
 ##
 image:
   repository: orangeopensource/casskop
-  tag: v2.0.1-release
+  tag: v2.0.2-release
   pullPolicy: Always
   imagePullSecrets:
     enabled: false

--- a/multi-casskop/helm/multi-casskop/Chart.yaml
+++ b/multi-casskop/helm/multi-casskop/Chart.yaml
@@ -4,8 +4,8 @@ name: multi-casskop
 home: https://github.com/Orange-OpenSource/casskop/multi-casskop
 sources:
   - https://github.com/Orange-OpenSource/casskop/multi-casskop
-version: 2.0.1
-appVersion: 2.0.1-release
+version: 2.0.2
+appVersion: 2.0.2-release
 maintainers:
   - name: allamand
     email: sebastien.allamand@orange.com

--- a/multi-casskop/helm/multi-casskop/values.yaml
+++ b/multi-casskop/helm/multi-casskop/values.yaml
@@ -2,7 +2,7 @@
 ##
 image:
   repository: orangeopensource/multi-casskop
-  tag: v2.0.1-release
+  tag: v2.0.2-release
   pullPolicy: Always
   imagePullSecrets:
     enabled: false

--- a/multi-casskop/version/version.go
+++ b/multi-casskop/version/version.go
@@ -15,5 +15,5 @@
 package version
 
 var (
-	Version = "2.0.1"
+	Version = "2.0.2"
 )

--- a/version/version.go
+++ b/version/version.go
@@ -15,5 +15,5 @@
 package version
 
 var (
-	Version = "2.0.1"
+	Version = "2.0.2"
 )


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | []
| New feature?    | []
| API breaks?     | []
| Deprecations?   | []
| License         | Apache 2.0


### What's in this PR?
Release 2.0.2

Update Documentation (#361)
Bump CRDs version from v1aplha1 to v2 (#363)
Added a possibility to configure readinessProbe timeouts for operator deployment (#362)
Do not mount multiple times the same path (#359)
Bump tar from 6.1.4 to 6.1.11 in /website (#356)
Limit ConfigBuilder resources and add ability to specify its image (#358)
Bump url-parse from 1.5.1 to 1.5.3 in /website (#354)
Bump path-parse from 1.0.6 to 1.0.7 in /website (#352)
Upgrade to Go 1.17 (#353)
Remove pre_stop.sh and update build image (#350)