### PR TITLE
[Backup] Do not validate Secret for file protocol

### DIFF
--- a/pkg/apis/db/v2/cassandrabackup_types.go
+++ b/pkg/apis/db/v2/cassandrabackup_types.go
@@ -154,3 +154,7 @@ func (backupSpec *CassandraBackup) IsAzureBackup() bool {
 func (backupSpec *CassandraBackup) IsGcpBackup() bool {
 	return strings.HasPrefix(backupSpec.Spec.StorageLocation, "gcp://")
 }
+
+func (backupSpec *CassandraBackup) IsFileBackup() bool {
+	return strings.HasPrefix(backupSpec.Spec.StorageLocation, "file://")
+}


### PR DESCRIPTION
File protocol does not need any authentication, but backup will
fail if secret is not set.
Check protocol type before validating secret.

Fixes #378

| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | []
| API breaks?     | []
| Deprecations?   | []
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0

