### PR TITLE
V2.1.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,16 @@
 
 # CassKop Cassandra Kubernetes Operator Changelog
 
+## v2.1.0
+
+- PR [397](https://github.com/Orange-OpenSource/casskop/pull/397) - Fix activation of Jolokia Auth
+- PR [396](https://github.com/Orange-OpenSource/casskop/pull/368) - Allow to configure VolumeMount for backrest-sidecar container
+- PR [380](https://github.com/Orange-OpenSource/casskop/pull/380) - Fix k3d version
+- PR [379](https://github.com/Orange-OpenSource/casskop/pull/379) - Do not validate Secret for file protocol in Backup
+- PR [377](https://github.com/Orange-OpenSource/casskop/pull/377) - Fix: update cc status if StatusFinalizing
+- PR [376](https://github.com/Orange-OpenSource/casskop/pull/376) - Bump operator sdk v1.13.0
+- PR [375](https://github.com/Orange-OpenSource/casskop/pull/375) - Fix issue #374 with determining the cassandra version from image
+
 ## v2.0.3
 
 - PR [368](https://github.com/Orange-OpenSource/casskop/pull/368) - Add missing changes of crd

--- a/helm/cassandra-operator/Chart.yaml
+++ b/helm/cassandra-operator/Chart.yaml
@@ -4,8 +4,8 @@ name: cassandra-operator
 home: https://github.com/Orange-OpenSource/casskop
 sources:
   - https://github.com/Orange-OpenSource/casskop
-version: 2.0.3
-appVersion: 2.0.3-release
+version: 2.1.0
+appVersion: 2.1.0-release
 maintainers:
   - name: allamand
     email: sebastien.allamand@orange.com

--- a/helm/cassandra-operator/Chart.yaml
+++ b/helm/cassandra-operator/Chart.yaml
@@ -7,18 +7,10 @@ sources:
 version: 2.1.0
 appVersion: 2.1.0-release
 maintainers:
-  - name: allamand
-    email: sebastien.allamand@orange.com
   - name: cscetbon
     email: cscetbon@gmail.com
-  - name: jal06
-    email: jeanarmel.luce@orange.com
-  - name: erdrix
-    email: aguitton.ext@orange.com
   - name: fdehay
     email: franck.dehay@orange.com
-  - name: PERES-Richard
-    email: richardperes.info@gmail.com
 keywords:
 - operator
 - cassandra

--- a/helm/cassandra-operator/values.yaml
+++ b/helm/cassandra-operator/values.yaml
@@ -2,7 +2,7 @@
 ##
 image:
   repository: orangeopensource/casskop
-  tag: v2.0.3-release
+  tag: v2.1.0-release
   pullPolicy: Always
   imagePullSecrets:
     enabled: false

--- a/multi-casskop/helm/multi-casskop/Chart.yaml
+++ b/multi-casskop/helm/multi-casskop/Chart.yaml
@@ -7,18 +7,10 @@ sources:
 version: 2.1.0
 appVersion: 2.1.0-release
 maintainers:
-  - name: allamand
-    email: sebastien.allamand@orange.com
   - name: cscetbon
     email: cscetbon@gmail.com
-  - name: jal06
-    email: jeanarmel.luce@orange.com
-  - name: erdrix
-    email: aguitton.ext@orange.com
   - name: fdehay
     email: franck.dehay@orange.com
-  - name: PERES-Richard
-    email: richardperes.info@gmail.com
 keywords:
 - operator
 - cassandra

--- a/multi-casskop/helm/multi-casskop/Chart.yaml
+++ b/multi-casskop/helm/multi-casskop/Chart.yaml
@@ -4,8 +4,8 @@ name: multi-casskop
 home: https://github.com/Orange-OpenSource/casskop/multi-casskop
 sources:
   - https://github.com/Orange-OpenSource/casskop/multi-casskop
-version: 2.0.3
-appVersion: 2.0.3-release
+version: 2.1.0
+appVersion: 2.1.0-release
 maintainers:
   - name: allamand
     email: sebastien.allamand@orange.com

--- a/multi-casskop/helm/multi-casskop/values.yaml
+++ b/multi-casskop/helm/multi-casskop/values.yaml
@@ -2,7 +2,7 @@
 ##
 image:
   repository: orangeopensource/multi-casskop
-  tag: v2.0.3-release
+  tag: v2.1.0-release
   pullPolicy: Always
   imagePullSecrets:
     enabled: false

--- a/multi-casskop/version/version.go
+++ b/multi-casskop/version/version.go
@@ -15,5 +15,5 @@
 package version
 
 var (
-	Version = "2.0.3"
+	Version = "2.1.0"
 )

--- a/version/version.go
+++ b/version/version.go
@@ -15,5 +15,5 @@
 package version
 
 var (
-	Version = "2.0.3"
+	Version = "2.1.0"
 )


### PR DESCRIPTION
### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
- PR [397](https://github.com/Orange-OpenSource/casskop/pull/397) - Fix activation of Jolokia Auth
- PR [396](https://github.com/Orange-OpenSource/casskop/pull/368) - Allow to configure VolumeMount for backrest-sidecar container
- PR [380](https://github.com/Orange-OpenSource/casskop/pull/380) - Fix k3d version
- PR [379](https://github.com/Orange-OpenSource/casskop/pull/379) - Do not validate Secret for file protocol in Backup
- PR [377](https://github.com/Orange-OpenSource/casskop/pull/377) - Fix: update cc status if StatusFinalizing
- PR [376](https://github.com/Orange-OpenSource/casskop/pull/376) - Bump operator sdk v1.13.0
- PR [375](https://github.com/Orange-OpenSource/casskop/pull/375) - Fix issue with determining the cassandra version from image
